### PR TITLE
prefers-reduced-motion svelte store

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "./utils": {
       "types": "./dist/utils/index.d.ts",
       "svelte": "./dist/utils/index.js"
+    },
+    "./stores": {
+      "types": "./dist/stores/index.d.ts",
+      "svelte": "./dist/stores/index.js"
     }
   },
   "files": [

--- a/src/lib/stores/index.js
+++ b/src/lib/stores/index.js
@@ -1,2 +1,2 @@
 // Reexport your entry components here
-export { default as reducedMotion } from "./reducedMotion.js";
+export { reducedMotion } from "./reducedMotion.js";

--- a/src/lib/stores/index.js
+++ b/src/lib/stores/index.js
@@ -1,0 +1,2 @@
+// Reexport your entry components here
+export { default as reducedMotion } from "./reducedMotion.js";

--- a/src/lib/stores/reducedMotion.js
+++ b/src/lib/stores/reducedMotion.js
@@ -2,11 +2,10 @@
 // Copied from Geoff Rich: https://geoffrich.net/posts/svelte-prefers-reduced-motion-store/
 // @ts-nocheck
 import { readable } from "svelte/store";
-import { browser } from "$app/environment";
 
 const reducedMotionQuery = "(prefers-reduced-motion: reduce)";
 const getInitialMotionPreference = () => {
-  if (browser) return window.matchMedia(reducedMotionQuery).matches;
+  if (typeof window !== "undefined") return window.matchMedia(reducedMotionQuery).matches;
 };
 
 export const reducedMotion = readable(getInitialMotionPreference(), (set) => {
@@ -14,7 +13,7 @@ export const reducedMotion = readable(getInitialMotionPreference(), (set) => {
     set(event.matches);
   };
 
-  if (browser) {
+  if (typeof window !== "undefined") {
     const mediaQueryList = window.matchMedia(reducedMotionQuery);
     mediaQueryList.addEventListener("change", updateMotionPreference);
 

--- a/src/lib/stores/reducedMotion.js
+++ b/src/lib/stores/reducedMotion.js
@@ -1,0 +1,25 @@
+// Svelte store to detect if client has reduced motion turned on (relevant for animations in radial visualization scrollytelling section)
+// Copied from Geoff Rich: https://geoffrich.net/posts/svelte-prefers-reduced-motion-store/
+// @ts-nocheck
+import { readable } from "svelte/store";
+import { browser } from "$app/environment";
+
+const reducedMotionQuery = "(prefers-reduced-motion: reduce)";
+const getInitialMotionPreference = () => {
+  if (browser) return window.matchMedia(reducedMotionQuery).matches;
+};
+
+export const reducedMotion = readable(getInitialMotionPreference(), (set) => {
+  const updateMotionPreference = (event) => {
+    set(event.matches);
+  };
+
+  if (browser) {
+    const mediaQueryList = window.matchMedia(reducedMotionQuery);
+    mediaQueryList.addEventListener("change", updateMotionPreference);
+
+    return () => {
+      mediaQueryList.removeEventListener("change", updateMotionPreference);
+    };
+  }
+});

--- a/src/stories/reducedMotion.mdx
+++ b/src/stories/reducedMotion.mdx
@@ -1,0 +1,37 @@
+import { Meta } from "@storybook/blocks";
+
+<Meta title="stores/reducedMotion" />
+
+# Reduced Motion Svelte Store
+
+A Svelte store that tracks the user's preference for reduced motion, adapted from [Geoff Rich's Accessible Svelte Transitions article](https://geoffrich.net/posts/accessible-svelte-transitions/).
+
+Sometimes users may turn on "prefers-reduced-motion" in their accessibility settings. If this is this is the case, they expect to see no animations or transitions. This store tracks the user's preference for reduced motion and can be used for conditional rendering.
+
+## Usage
+
+In the example below, the tweened store can be used to animate a component position. If the user has reduced motion enabled, the animation duration is reduced to 0.
+
+```js
+import { reducedMotion } from "@urbaninstitute/dataviz-components/stores";
+import { tweened } from "svelte/motion";
+
+const tween = tweened(0, {
+  duration: $reducedMotion ? 0 : 500,
+  easing: cubicOut
+});
+```
+
+## Additional CSS for prefers-reduced-motion
+
+It's worth noting that some simple CSS like the following will disable most Svelte native transitions and animations. The store above is useful if an animation function is not covered by this media query.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-delay: 0ms !important;
+    animation-duration: 1ms !important;
+    transition: none !important;
+  }
+}
+```

--- a/src/stories/reducedMotion.mdx
+++ b/src/stories/reducedMotion.mdx
@@ -2,11 +2,11 @@ import { Meta } from "@storybook/blocks";
 
 <Meta title="stores/reducedMotion" />
 
-# Reduced Motion Svelte Store
+# prefers-reduced-motion Svelte Store
 
 A Svelte store that tracks the user's preference for reduced motion, adapted from [Geoff Rich's Accessible Svelte Transitions article](https://geoffrich.net/posts/accessible-svelte-transitions/).
 
-Sometimes users may turn on "prefers-reduced-motion" in their accessibility settings. If this is this is the case, they expect to see no animations or transitions. This store tracks the user's preference for reduced motion and can be used for conditional rendering.
+Sometimes users may turn on "prefers-reduced-motion" in their accessibility settings. If this is this is the case, they expect to see no animations or transitions. This store uses `window.matchMedia()` to track the user's preference for reduced motion and can be used for conditional rendering.
 
 ## Usage
 
@@ -24,7 +24,7 @@ const tween = tweened(0, {
 
 ## Additional CSS for prefers-reduced-motion
 
-It's worth noting that some simple CSS like the following will disable most Svelte native transitions and animations. The store above is useful if an animation function is not covered by this media query.
+It's worth noting that CSS like the following will disable most native Svelte transitions and animations. The `$reducedMotion` store above is useful if an animation function is not covered by this media query.
 
 ```css
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Adds a Svelte store for detecting prefers-reduced-motion, based on [Geoff Rich's work](https://geoffrich.net/posts/accessible-svelte-transitions/).