### PR TITLE
Convert TextBlock/ProjectCredits to accept value as slot

### DIFF
--- a/src/lib/ProjectCredits/ProjectCredits.stories.svelte
+++ b/src/lib/ProjectCredits/ProjectCredits.stories.svelte
@@ -10,13 +10,11 @@
 </script>
 
 <script>
+  import TextBlock from "$lib/TextBlock/TextBlock.svelte";
   import { Story, Template } from "@storybook/addon-svelte-csf";
 
   const sample_data = {
     heading: "Project credits",
-    text: [
-      "<em>Vitae turpis massa sed elementum tempus. At quis risus sed vulputate odio ut enim blandit volutpat. Odio ut sem nulla pharetra. Diam maecenas sed enim ut sem viverra. Nunc lobortis mattis aliquam faucibus purus in massa. Vel eros donec ac odio tempor orci. Viverra tellus in hac habitasse platea. Eget nunc scelerisque viverra mauris in aliquam set egestas quis. Integer enim neque volutpat ac tincidunt vitae semper quis. Sociis natoque penatibus et magnis dis parturient montes nascetur ridiculus.</em>"
-    ],
     items: [
       {
         label: "Research",
@@ -33,14 +31,25 @@
       {
         label: "Writing",
         content: "<a href='https://www.urban.org/' target='_blank'>Firstname Lastname</a>"
-      },
+      }
     ],
     githubUrl: "https://github.com/urbaninstitute/dataviz-components"
   };
 </script>
 
 <Template let:args>
-  <ProjectCredits {...args} />
+  <ProjectCredits {...args}>
+    <TextBlock slot="intro"
+      ><em
+        >Vitae turpis massa sed elementum tempus. At quis risus sed vulputate odio ut enim blandit
+        volutpat. Odio ut sem nulla pharetra. Diam maecenas sed enim ut sem viverra. Nunc lobortis
+        mattis aliquam faucibus purus in massa. Vel eros donec ac odio tempor orci. Viverra tellus
+        in hac habitasse platea. Eget nunc scelerisque viverra mauris in aliquam set egestas quis.
+        Integer enim neque volutpat ac tincidunt vitae semper quis. Sociis natoque penatibus et
+        magnis dis parturient montes nascetur ridiculus.</em
+      ></TextBlock
+    >
+  </ProjectCredits>
 </Template>
 
-<Story name="Default" args={{...sample_data}} />
+<Story name="Default" args={{ ...sample_data }} />

--- a/src/lib/ProjectCredits/ProjectCredits.svelte
+++ b/src/lib/ProjectCredits/ProjectCredits.svelte
@@ -11,12 +11,6 @@
   export let heading;
 
   /**
-   * Paragraphs of text to display within credits block
-   * @type {string[]}
-   */
-  export let text;
-
-  /**
    * The credit items to display
    * @type {{label: string, content: string}[]}
    */
@@ -32,9 +26,7 @@
 <Block>
   <Heading content={heading} />
 </Block>
-{#each text as value}
-  <TextBlock {value} />
-{/each}
+<slot name="intro" />
 <Block>
   <ul>
     {#each items as item}

--- a/src/lib/ProjectCredits/ProjectCredits.svelte
+++ b/src/lib/ProjectCredits/ProjectCredits.svelte
@@ -26,6 +26,7 @@
 <Block>
   <Heading content={heading} />
 </Block>
+<!-- Content to render between the heading and the items -->
 <slot name="intro" />
 <Block>
   <ul>
@@ -38,7 +39,7 @@
   </ul>
 </Block>
 {#if githubUrl}
-  <TextBlock content="View the project on <a href='{githubUrl}' target='_blank'>Github</a>." />
+  <TextBlock>View the project on <a href={githubUrl} target="_blank">Github</a>.</TextBlock>
 {/if}
 
 <style>

--- a/src/lib/TextBlock/TextBlock.stories.svelte
+++ b/src/lib/TextBlock/TextBlock.stories.svelte
@@ -1,11 +1,11 @@
 <script context="module">
-	import TextBlock from "./TextBlock.svelte";
+  import TextBlock from "./TextBlock.svelte";
 
-	export const meta = {
-		title: "Components/TextBlock",
-		description: "A basic text block",
-		component: TextBlock,
-		tags: ["autodocs"],
+  export const meta = {
+    title: "Components/TextBlock",
+    description: "A basic text block",
+    component: TextBlock,
+    tags: ["autodocs"],
     argTypes: {
       width: {
         default: "body",
@@ -17,7 +17,6 @@
         options: ["primary", "reverse"],
         control: "select"
       }
-
     },
     parameters: {
       backgrounds: {
@@ -28,46 +27,71 @@
         ]
       }
     }
-      
-	};
+  };
 </script>
 
 <script>
-	import { Story, Template } from "@storybook/addon-svelte-csf";
-
+  import { Story, Template } from "@storybook/addon-svelte-csf";
 </script>
 
-<Template let:args>
-	<TextBlock {...args} />
-</Template>
+<!-- <Template let:args>
+  <TextBlock {...args} />
+</Template> -->
+
+<Story name="Default">
+  <TextBlock>
+    <svelte:fragment
+      >Enim id qui labore labore quis ut enim tempor sint quis proident voluptate ex. Duis nisi
+      minim et occaecat do ullamco nisi dolore ipsum proident tempor aute exercitation duis.
+      Proident pariatur consectetur tempor mollit Lorem deserunt. Ut laboris est cillum ut dolore
+      quis consectetur nostrud ut cupidatat enim ea cupidatat ipsum. Voluptate esse labore
+      incididunt sint eiusmod ullamco mollit consequat.</svelte:fragment
+    >
+  </TextBlock>
+</Story>
+
+<Story name="With HTML content">
+  <TextBlock>
+    <svelte:fragment
+      >Enim id qui <a href="https://urban.org" target="_blank">labore labore quis</a> ut enim tempor
+      sint quis proident voluptate ex. Duis nisi minim et occaecat do ullamco nisi dolore ipsum proident
+      tempor aute exercitation duis. Proident pariatur consectetur tempor mollit Lorem deserunt. Ut laboris
+      est cillum ut dolore quis consectetur nostrud ut cupidatat enim ea cupidatat ipsum. Voluptate esse
+      labore incididunt sint eiusmod ullamco mollit consequat.</svelte:fragment
+    >
+  </TextBlock>
+</Story>
 
 <Story
-	name="Default"
+  name="Reversed variant"
+  parameters={{ backgrounds: { default: "dark" } }}
   args={{
-    value: "Enim id qui labore labore quis ut enim tempor sint quis proident voluptate ex. Duis nisi minim et occaecat do ullamco nisi dolore ipsum proident tempor aute exercitation duis. Proident pariatur consectetur tempor mollit Lorem deserunt. Ut laboris est cillum ut dolore quis consectetur nostrud ut cupidatat enim ea cupidatat ipsum. Voluptate esse labore incididunt sint eiusmod ullamco mollit consequat.",
-  }}
-/>
-
-<Story
-	name="With HTML content"
-  args={{
-    value: "Enim id qui <a href='https://urban.org' target='_blank'>labore labore quis</a> ut enim tempor sint quis proident voluptate ex. Duis nisi minim et occaecat do ullamco nisi dolore ipsum proident tempor aute exercitation duis. Proident pariatur consectetur tempor mollit Lorem deserunt. Ut laboris est cillum ut dolore quis consectetur nostrud ut cupidatat enim ea cupidatat ipsum. Voluptate esse labore incididunt sint eiusmod ullamco mollit consequat.",
-  }}
-/>
-
-<Story
-	name="Reversed variant"
-  parameters={{backgrounds: {default: "dark"}}}
-  args={{
-    value: "Enim id qui <a href='https://urban.org' target='_blank'>labore labore quis</a> ut enim tempor sint quis proident voluptate ex. Duis nisi minim et occaecat do ullamco nisi dolore ipsum proident tempor aute exercitation duis. Proident pariatur consectetur tempor mollit Lorem deserunt. Ut laboris est cillum ut dolore quis consectetur nostrud ut cupidatat enim ea cupidatat ipsum. Voluptate esse labore incididunt sint eiusmod ullamco mollit consequat.",
     variant: "reverse"
   }}
-/>
+>
+  <TextBlock>
+    <svelte:fragment>
+      Enim id qui <a href="https://urban.org" target="_blank">labore labore quis</a> ut enim tempor sint
+      quis proident voluptate ex. Duis nisi minim et occaecat do ullamco nisi dolore ipsum proident tempor
+      aute exercitation duis. Proident pariatur consectetur tempor mollit Lorem deserunt. Ut laboris
+      est cillum ut dolore quis consectetur nostrud ut cupidatat enim ea cupidatat ipsum. Voluptate esse
+      labore incididunt sint eiusmod ullamco mollit consequat.
+    </svelte:fragment>
+  </TextBlock>
+</Story>
 
 <Story
-	name="With color override"
+  name="With color override"
   args={{
-    value: "Enim id qui <a href='https://urban.org' target='_blank'>labore labore quis</a> ut enim tempor sint quis proident voluptate ex. Duis nisi minim et occaecat do ullamco nisi dolore ipsum proident tempor aute exercitation duis. Proident pariatur consectetur tempor mollit Lorem deserunt. Ut laboris est cillum ut dolore quis consectetur nostrud ut cupidatat enim ea cupidatat ipsum. Voluptate esse labore incididunt sint eiusmod ullamco mollit consequat.",
     color: "#0a4c6a"
   }}
-/>
+  ><TextBlock
+    ><svelte:fragment
+      >Enim id qui <a href="https://urban.org" target="_blank">labore labore quis</a> ut enim tempor
+      sint quis proident voluptate ex. Duis nisi minim et occaecat do ullamco nisi dolore ipsum proident
+      tempor aute exercitation duis. Proident pariatur consectetur tempor mollit Lorem deserunt. Ut laboris
+      est cillum ut dolore quis consectetur nostrud ut cupidatat enim ea cupidatat ipsum. Voluptate esse
+      labore incididunt sint eiusmod ullamco mollit consequat.</svelte:fragment
+    ></TextBlock
+  ></Story
+>

--- a/src/lib/TextBlock/TextBlock.stories.svelte
+++ b/src/lib/TextBlock/TextBlock.stories.svelte
@@ -34,64 +34,37 @@
   import { Story, Template } from "@storybook/addon-svelte-csf";
 </script>
 
-<!-- <Template let:args>
-  <TextBlock {...args} />
-</Template> -->
-
-<Story name="Default">
-  <TextBlock>
-    <svelte:fragment
-      >Enim id qui labore labore quis ut enim tempor sint quis proident voluptate ex. Duis nisi
-      minim et occaecat do ullamco nisi dolore ipsum proident tempor aute exercitation duis.
-      Proident pariatur consectetur tempor mollit Lorem deserunt. Ut laboris est cillum ut dolore
-      quis consectetur nostrud ut cupidatat enim ea cupidatat ipsum. Voluptate esse labore
-      incididunt sint eiusmod ullamco mollit consequat.</svelte:fragment
-    >
+<Template let:args>
+  <TextBlock {...args}>
+    Enim id qui labore labore quis ut enim tempor sint quis proident voluptate ex. Duis nisi minim
+    et occaecat do ullamco nisi dolore ipsum proident tempor aute exercitation duis. Proident
+    pariatur consectetur tempor mollit Lorem deserunt. Ut laboris est cillum ut dolore quis
+    consectetur nostrud ut cupidatat enim ea cupidatat ipsum. Voluptate esse labore incididunt sint
+    eiusmod ullamco mollit consequat.
   </TextBlock>
-</Story>
+</Template>
+
+<Story name="Default" />
 
 <Story name="With HTML content">
   <TextBlock>
-    <svelte:fragment
-      >Enim id qui <a href="https://urban.org" target="_blank">labore labore quis</a> ut enim tempor
-      sint quis proident voluptate ex. Duis nisi minim et occaecat do ullamco nisi dolore ipsum proident
-      tempor aute exercitation duis. Proident pariatur consectetur tempor mollit Lorem deserunt. Ut laboris
-      est cillum ut dolore quis consectetur nostrud ut cupidatat enim ea cupidatat ipsum. Voluptate esse
-      labore incididunt sint eiusmod ullamco mollit consequat.</svelte:fragment
-    >
+    Enim id qui <a href="https://urban.org" target="_blank">labore labore quis</a> ut enim tempor sint
+    quis proident voluptate ex. Duis nisi minim et occaecat do ullamco nisi dolore ipsum proident tempor
+    aute exercitation duis. Proident pariatur consectetur tempor mollit Lorem deserunt. Ut laboris est
+    cillum ut dolore quis consectetur nostrud ut cupidatat enim ea cupidatat ipsum. Voluptate esse labore
+    incididunt sint eiusmod ullamco mollit consequat.
   </TextBlock>
 </Story>
 
 <Story
   name="Reversed variant"
   parameters={{ backgrounds: { default: "dark" } }}
-  args={{
-    variant: "reverse"
-  }}
->
-  <TextBlock>
-    <svelte:fragment>
-      Enim id qui <a href="https://urban.org" target="_blank">labore labore quis</a> ut enim tempor sint
-      quis proident voluptate ex. Duis nisi minim et occaecat do ullamco nisi dolore ipsum proident tempor
-      aute exercitation duis. Proident pariatur consectetur tempor mollit Lorem deserunt. Ut laboris
-      est cillum ut dolore quis consectetur nostrud ut cupidatat enim ea cupidatat ipsum. Voluptate esse
-      labore incididunt sint eiusmod ullamco mollit consequat.
-    </svelte:fragment>
-  </TextBlock>
-</Story>
+  args={{ variant: "reverse" }}
+/>
 
 <Story
   name="With color override"
   args={{
     color: "#0a4c6a"
   }}
-  ><TextBlock
-    ><svelte:fragment
-      >Enim id qui <a href="https://urban.org" target="_blank">labore labore quis</a> ut enim tempor
-      sint quis proident voluptate ex. Duis nisi minim et occaecat do ullamco nisi dolore ipsum proident
-      tempor aute exercitation duis. Proident pariatur consectetur tempor mollit Lorem deserunt. Ut laboris
-      est cillum ut dolore quis consectetur nostrud ut cupidatat enim ea cupidatat ipsum. Voluptate esse
-      labore incididunt sint eiusmod ullamco mollit consequat.</svelte:fragment
-    ></TextBlock
-  ></Story
->
+/>

--- a/src/lib/TextBlock/TextBlock.svelte
+++ b/src/lib/TextBlock/TextBlock.svelte
@@ -1,11 +1,6 @@
 <script>
   import "../style/app.css";
   import Block from "$lib/Block/Block.svelte";
-  /**
-   * The text to display in the block. Allows HTML content.
-   * @type {string} [value]
-   */
-  export let value;
 
   /**
    * The width of the text block. Defaults to "body" (max-width: 760px)
@@ -33,7 +28,7 @@
     style:color
     style={`--color-override: ${color}`}
   >
-    {@html value}
+    <slot />
   </p>
 </Block>
 

--- a/src/lib/TextBlock/TextBlock.svelte
+++ b/src/lib/TextBlock/TextBlock.svelte
@@ -28,6 +28,7 @@
     style:color
     style={`--color-override: ${color}`}
   >
+    <!-- HTML or text content to render inside of the component -->
     <slot />
   </p>
 </Block>


### PR DESCRIPTION
This is mainly a change to `TextBlock`, which is then used by `ProjectCredits`. The value is now passed via child slots, namely inside a `<svelte:fragment>`.

TODO: add documentation for slots in the `TextBlock` and `ProjectCredits` stories
TODO: color reverse in `TextBlock` is now broken