### PR TITLE
Add component descriptions to story pages via parameters.docs.description.component

### DIFF
--- a/src/lib/BasicDropdown/BasicDropdown.stories.svelte
+++ b/src/lib/BasicDropdown/BasicDropdown.stories.svelte
@@ -13,7 +13,7 @@
     parameters: {
       docs: {
         description: {
-          component: "Basic HTML dropdown."
+          component: "Basic HTML dropdown adhering to Urban styles."
         }
       }
     }

--- a/src/lib/BasicDropdown/BasicDropdown.stories.svelte
+++ b/src/lib/BasicDropdown/BasicDropdown.stories.svelte
@@ -1,73 +1,80 @@
 <script context="module">
-	import BasicDropdown from "./BasicDropdown.svelte";
+  import BasicDropdown from "./BasicDropdown.svelte";
 
-	export const meta = {
-		title: "Components/BasicDropdown",
-		description: "A basic dropdown component that uses a <select> element under the hood.",
-		component: BasicDropdown,
-		tags: ["autodocs"],
-		argTypes: {
-			arrow_fill_color: { control: "color" },
-			data: { control: "object" }
-		}
-	};
+  export const meta = {
+    title: "Components/BasicDropdown",
+    description: "A basic dropdown component that uses a <select> element under the hood.",
+    component: BasicDropdown,
+    tags: ["autodocs"],
+    argTypes: {
+      arrow_fill_color: { control: "color" },
+      data: { control: "object" }
+    },
+    parameters: {
+      docs: {
+        description: {
+          component: "Basic HTML dropdown."
+        }
+      }
+    }
+  };
 </script>
 
 <script>
-	import { Story, Template } from "@storybook/addon-svelte-csf";
-	import { fireEvent, within, expect } from "@storybook/test";
+  import { Story, Template } from "@storybook/addon-svelte-csf";
+  import { fireEvent, within, expect } from "@storybook/test";
 
-	const sampleData = [
-		{ value: "Ohio", label: "Ohio" },
-		{ value: "Pennsylvania", label: "Pennsylvania" },
-		{ value: "New York", label: "New York" },
-		{ value: "Maryland", label: "Maryland" }
-	];
+  const sampleData = [
+    { value: "Ohio", label: "Ohio" },
+    { value: "Pennsylvania", label: "Pennsylvania" },
+    { value: "New York", label: "New York" },
+    { value: "Maryland", label: "Maryland" }
+  ];
 </script>
 
 <Template let:args>
-	<BasicDropdown {...args} />
+  <BasicDropdown {...args} />
 </Template>
 
 <Story
-	name="Default"
-	args={{
-		id: "dropdown-story",
-		dropdown_width: 260,
-		inline_label: "Dropdown label",
-		arrow_fill_color: "#1696D1",
-		placeholder: "Select a state",
-		data: sampleData
-	}}
+  name="Default"
+  args={{
+    id: "dropdown-story",
+    dropdown_width: 260,
+    inline_label: "Dropdown label",
+    arrow_fill_color: "#1696D1",
+    placeholder: "Select a state",
+    data: sampleData
+  }}
 />
 
 <Story
-	name="With value specified"
-	args={{
-		id: "dropdown-story-2",
-		inline_label: "Dropdown with value",
-		placeholder: "Select a state",
-		value: "Ohio",
-		data: sampleData
-	}}
+  name="With value specified"
+  args={{
+    id: "dropdown-story-2",
+    inline_label: "Dropdown with value",
+    placeholder: "Select a state",
+    value: "Ohio",
+    data: sampleData
+  }}
 />
 
 <Story
-	name="With value selected"
-	args={{
-		id: "dropdown-story-2",
-		inline_label: "Dropdown with selected value",
-		placeholder: "Select a state",
-		data: sampleData
-	}}
-	play={async ({ canvasElement }) => {
-		const canvas = within(canvasElement);
-		const selectEl = canvas.getByLabelText("Dropdown with selected value", {
-			selector: "select"
-		});
-    await fireEvent.change(selectEl, {target: {value: sampleData[1].value}})
-    expect(selectEl.value).toBe(sampleData[1].value)
-    await fireEvent.change(selectEl, {target: {value: sampleData[3].value}})
-    expect(selectEl.value).toBe(sampleData[3].value)
-	}}
+  name="With value selected"
+  args={{
+    id: "dropdown-story-2",
+    inline_label: "Dropdown with selected value",
+    placeholder: "Select a state",
+    data: sampleData
+  }}
+  play={async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const selectEl = canvas.getByLabelText("Dropdown with selected value", {
+      selector: "select"
+    });
+    await fireEvent.change(selectEl, { target: { value: sampleData[1].value } });
+    expect(selectEl.value).toBe(sampleData[1].value);
+    await fireEvent.change(selectEl, { target: { value: sampleData[3].value } });
+    expect(selectEl.value).toBe(sampleData[3].value);
+  }}
 />

--- a/src/lib/Block/Block.stories.svelte
+++ b/src/lib/Block/Block.stories.svelte
@@ -1,11 +1,11 @@
 <script context="module">
-	import Block from "./Block.svelte";
+  import Block from "./Block.svelte";
 
-	export const meta = {
-		title: "Layout/Block",
-		description: "A basic building block of a page",
-		component: Block,
-		tags: ["autodocs"],
+  export const meta = {
+    title: "Layout/Block",
+    description: "A basic building block of a page",
+    component: Block,
+    tags: ["autodocs"],
     argTypes: {
       width: {
         default: "body",
@@ -13,36 +13,40 @@
         control: "select"
       }
     },
-      
-	};
+    parameters: {
+      docs: {
+        description: {
+          component: "A basic content block."
+        }
+      }
+    }
+  };
 </script>
 
 <script>
-	import { Story, Template } from "@storybook/addon-svelte-csf";
-
+  import { Story, Template } from "@storybook/addon-svelte-csf";
 </script>
 
 <Template let:args>
-	<Block {...args} >
-    <div style="width: 100%; height: 200px; background: #d2d2d2; display: flex; align-items: center; justify-content: center;">Block</div>
+  <Block {...args}>
+    <div
+      style="width: 100%; height: 200px; background: #d2d2d2; display: flex; align-items: center; justify-content: center;"
+    >
+      Block
+    </div>
   </Block>
 </Template>
 
+<Story name="Default" args={{}} />
 <Story
-	name="Default"
-  args={{
-  }}
-/>
-<Story
-	name="Full width"
+  name="Full width"
   args={{
     width: "full"
   }}
 />
 <Story
-	name="Wide"
+  name="Wide"
   args={{
     width: "wide"
   }}
 />
-

--- a/src/lib/HeadingAlt/HeadingAlt.stories.svelte
+++ b/src/lib/HeadingAlt/HeadingAlt.stories.svelte
@@ -1,25 +1,31 @@
 <script context="module">
-	import Heading from "./HeadingAlt.svelte";
+  import Heading from "./HeadingAlt.svelte";
 
-	export const meta = {
-		title: "Components/HeadingAlt",
-		description: "A block for an alternate heading",
-		component: Heading,
-		tags: ["autodocs"],
-	};
+  export const meta = {
+    title: "Components/HeadingAlt",
+    description: "A block for an alternate heading",
+    component: Heading,
+    tags: ["autodocs"],
+    parameters: {
+      docs: {
+        description: {
+          component: "Alternate title heading in all caps, useful for h2 tags and lower."
+        }
+      }
+    }
+  };
 </script>
 
 <script>
-	import { Story, Template } from "@storybook/addon-svelte-csf";
-
+  import { Story, Template } from "@storybook/addon-svelte-csf";
 </script>
 
 <Template let:args>
-	<Heading {...args} />
+  <Heading {...args} />
 </Template>
 
 <Story
-	name="Default"
+  name="Default"
   args={{
     content: "This is an alternate heading"
   }}

--- a/src/lib/LogoTPCBadge/LogoTPCBadge.stories.svelte
+++ b/src/lib/LogoTPCBadge/LogoTPCBadge.stories.svelte
@@ -5,7 +5,14 @@
     title: "Components/LogoTPCBadge",
     description: "A Tax Policy Center logo",
     component: Logo,
-    tags: ["autodocs"]
+    tags: ["autodocs"],
+    parameters: {
+      docs: {
+        description: {
+          component: "Tax Policy Center logo in square badge format."
+        }
+      }
+    }
   };
 </script>
 

--- a/src/lib/LogoUrban/LogoUrban.stories.svelte
+++ b/src/lib/LogoUrban/LogoUrban.stories.svelte
@@ -19,6 +19,11 @@
           { name: "light", value: "#ffffff" },
           { name: "dark", value: "#0A4C6A" }
         ]
+      },
+      docs: {
+        description: {
+          component: "Urban Institute logo in full width format."
+        }
       }
     }
   };
@@ -33,4 +38,8 @@
 </Template>
 
 <Story name="Default" />
-<Story name="Variant - white" args={{variant: "white"}} parameters={{backgrounds: {default: "dark"}}}/>
+<Story
+  name="Variant - white"
+  args={{ variant: "white" }}
+  parameters={{ backgrounds: { default: "dark" } }}
+/>

--- a/src/lib/LogoUrbanBadge/LogoUrbanBadge.stories.svelte
+++ b/src/lib/LogoUrbanBadge/LogoUrbanBadge.stories.svelte
@@ -5,12 +5,20 @@
     title: "Components/LogoUrbanBadge",
     description: "An Urban Institute badge logo",
     component: Logo,
-    tags: ["autodocs"]
+    tags: ["autodocs"],
+    parameters: {
+      docs: {
+        description: {
+          component: "Urban Institute logo in square badge format."
+        }
+      }
+    }
   };
 </script>
 
 <script>
-  import { Story, Template } from "@storybook/addon-svelte-csf"; </script>
+  import { Story, Template } from "@storybook/addon-svelte-csf";
+</script>
 
 <Template let:args>
   <Logo {...args} />

--- a/src/lib/Navbar/Navbar.stories.svelte
+++ b/src/lib/Navbar/Navbar.stories.svelte
@@ -1,11 +1,11 @@
 <script context="module">
-	import Navbar from "./Navbar.svelte";
+  import Navbar from "./Navbar.svelte";
 
-	export const meta = {
-		title: "Components/Navbar",
-		description: "A basic navbar",
-		component: Navbar,
-		tags: ["autodocs"],
+  export const meta = {
+    title: "Components/Navbar",
+    description: "A basic navbar",
+    component: Navbar,
+    tags: ["autodocs"],
     argTypes: {
       brand: {
         default: "urban",
@@ -13,24 +13,29 @@
         control: "select"
       }
     },
-	};
+    parameters: {
+      docs: {
+        description: {
+          component:
+            "Full width navigation bar for top of page. Includes <code>brand</code> and <code>sticky</code> properties for Urban/TPC logo and absolute position controls respectively."
+        }
+      }
+    }
+  };
 </script>
 
 <script>
-	import { Story, Template } from "@storybook/addon-svelte-csf";
-
+  import { Story, Template } from "@storybook/addon-svelte-csf";
 </script>
 
 <Template let:args>
-	<Navbar {...args} />
+  <Navbar {...args} />
 </Template>
 
-<Story
-	name="Default"
-/>
+<Story name="Default" />
 
 <Story
-	name="With title"
+  name="With title"
   args={{
     title: "Project title",
     projectUrl: "https://urban.org"
@@ -38,7 +43,7 @@
 />
 
 <Story
-	name="Sticky"
+  name="Sticky"
   args={{
     title: "Project title",
     projectUrl: "https://urban.org",
@@ -47,7 +52,7 @@
 />
 
 <Story
-	name="TPC"
+  name="TPC"
   args={{
     title: "Project title",
     projectUrl: "https://urban.org",

--- a/src/lib/ProjectCredits/ProjectCredits.stories.svelte
+++ b/src/lib/ProjectCredits/ProjectCredits.stories.svelte
@@ -5,7 +5,14 @@
     title: "Components/ProjectCredits",
     description: "A block for project credits",
     component: ProjectCredits,
-    tags: ["autodocs"]
+    tags: ["autodocs"],
+    parameters: {
+      docs: {
+        description: {
+          component: "A block for project credits"
+        }
+      }
+    }
   };
 </script>
 

--- a/src/lib/ProjectCredits/ProjectCredits.stories.svelte
+++ b/src/lib/ProjectCredits/ProjectCredits.stories.svelte
@@ -9,7 +9,7 @@
     parameters: {
       docs: {
         description: {
-          component: "A block for project credits"
+          component: "A block for project credits."
         }
       }
     }

--- a/src/lib/ReturnTop/ReturnTop.stories.svelte
+++ b/src/lib/ReturnTop/ReturnTop.stories.svelte
@@ -5,7 +5,14 @@
     title: "Components/ReturnTop",
     description: "A button for moving the browser to a specified element ID",
     component: ReturnTop,
-    tags: ["autodocs"]
+    tags: ["autodocs"],
+    parameters: {
+      docs: {
+        description: {
+          component: "A button for moving the browser to a specified element ID."
+        }
+      }
+    }
   };
 </script>
 

--- a/src/lib/Scorecard/Scorecard.stories.svelte
+++ b/src/lib/Scorecard/Scorecard.stories.svelte
@@ -1,27 +1,34 @@
 <script context="module">
-	import Scorecard from "./Scorecard.svelte";
+  import Scorecard from "./Scorecard.svelte";
 
-	export const meta = {
-		title: "Components/Scorecard",
+  export const meta = {
+    title: "Components/Scorecard",
     description: "A scorecard that displays a value and a label",
-		component: Scorecard,
-		tags: ["autodocs"],
-	};
+    component: Scorecard,
+    tags: ["autodocs"],
+    parameters: {
+      docs: {
+        description: {
+          component:
+            "Scorecard element, which displays a value and a label, originally developed for <a href='https://www.urban.org/policy-centers/center-labor-human-services-and-population/projects/apprenticeship-support' target='_blank'>this project</a>."
+        }
+      }
+    }
+  };
 </script>
 
 <script>
-	import { Story, Template } from "@storybook/addon-svelte-csf";
-
+  import { Story, Template } from "@storybook/addon-svelte-csf";
 </script>
 
 <Template let:args>
-	<Scorecard {...args} />
+  <Scorecard {...args} />
 </Template>
 
 <Story
-	name="Default"
-	args={{
-		value: "9,001",
-		label: "Visualizations",
-	}}
+  name="Default"
+  args={{
+    value: "9,001",
+    label: "Visualizations"
+  }}
 />

--- a/src/lib/SocialShare/SocialShare.stories.svelte
+++ b/src/lib/SocialShare/SocialShare.stories.svelte
@@ -1,6 +1,6 @@
 <script context="module">
   import SocialShare from "./SocialShare.svelte";
-  import { fn, userEvent, within, expect } from '@storybook/test';
+  import { fn, userEvent, within, expect } from "@storybook/test";
 
   export const meta = {
     title: "Components/SocialShare",
@@ -8,7 +8,7 @@
     component: SocialShare,
     tags: ["autodocs"],
     args: {
-      shareUrl: "https://urban.org",
+      shareUrl: "https://urban.org"
     },
     argTypes: {
       variant: {
@@ -24,6 +24,11 @@
           { name: "light", value: "#ffffff" },
           { name: "dark", value: "#0A4C6A" }
         ]
+      },
+      docs: {
+        description: {
+          component: "Social share icons, available in light or dark mode."
+        }
       }
     }
   };
@@ -48,7 +53,8 @@
 <Story
   name="With custom onClick handler"
   args={{
-    onClick: fn()}}
+    onClick: fn()
+  }}
   play={async ({ args, canvasElement }) => {
     await userEvent.click(within(canvasElement).getByLabelText("email-share"));
     await expect(args.onClick).toHaveBeenCalled();

--- a/src/lib/TextBlock/TextBlock.stories.svelte
+++ b/src/lib/TextBlock/TextBlock.stories.svelte
@@ -25,6 +25,11 @@
           { name: "light", value: "#ffffff" },
           { name: "dark", value: "#0A4C6A" }
         ]
+      },
+      docs: {
+        description: {
+          component: "A basic text block."
+        }
       }
     }
   };


### PR DESCRIPTION
Goal is to add text on each story page, describing the component and giving additional context.

Documentation on this parameters.docs API can be found here: https://storybook.js.org/docs/api/doc-block-description#writing-descriptions