### PR TITLE
Add ChartBlock component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # @UrbanInstitute/dataviz-components Changelog
 
 ## Next
+- Add ChartBlock component
 - Add Button component
 
 - Updates Github action versions

--- a/src/lib/ChartBlock/ChartBlock.stories.svelte
+++ b/src/lib/ChartBlock/ChartBlock.stories.svelte
@@ -1,0 +1,70 @@
+<script context="module">
+  import ChartBlock from "./ChartBlock.svelte";
+  import DatawrapperIframe from "../DatawrapperIframe/DatawrapperIframe.svelte";
+
+  export const meta = {
+    title: "Components/ChartBlock",
+    description: "A basic wrapper for charts that includes, title, description, source, and notes.",
+    component: ChartBlock,
+    tags: ["autodocs"],
+    argTypes: {
+      width: {
+        default: "body",
+        options: ["body", "wide", "full"],
+        control: "select"
+      }
+    },
+    parameters: {
+      backgrounds: {
+        default: "light",
+        values: [
+          { name: "light", value: "#ffffff" },
+          { name: "dark", value: "#0A4C6A" }
+        ]
+      },
+      docs: {
+        description: {
+          component: "A basic wrapper for charts that includes, title, description, source, and notes. The default slot can be used to include any type of content or visualization between the provided text."
+        }
+      }
+    }
+  };
+</script>
+
+<script>
+  import { Story, Template } from "@storybook/addon-svelte-csf";
+
+  const chartArgs = {
+    title: "Chart title",
+    description: "Chart description",
+    source: "Chart source",
+    notes: "Chart notes"
+  };
+</script>
+
+<Template let:args>
+  <ChartBlock {...args}>
+    <div
+      style="height: 350px; width: 100%; background: #dededd; color: #000000; display: flex; align-items: center; justify-content: center;"
+    >
+      Chart area
+    </div>
+  </ChartBlock>
+</Template>
+
+<Story name="Default" args={chartArgs} />
+
+<Story
+  name="Custom text color"
+  parameters={{ backgrounds: { default: "dark" } }}
+  args={{ ...chartArgs, color: "#FFFFFF" }}
+/>
+<Story name="With a Datawrapper chart" args={{ ...chartArgs, color: "#FFFFFF" }}>
+  <ChartBlock title="Datawrapper chart" description="This is what a Datawrapper looks like inside this component." source="Chart source" notes="Chart notes">
+    <DatawrapperIframe
+      title="Datawrapper title"
+      ariaLabel="This is an accessible title for the visualization"
+      datawrapperId="RMnkX"
+    />
+  </ChartBlock>
+</Story>

--- a/src/lib/ChartBlock/ChartBlock.svelte
+++ b/src/lib/ChartBlock/ChartBlock.svelte
@@ -1,0 +1,91 @@
+<!-- @component ChartBlock - A basic chart wrapper that includes, title, description, source, and notes. -->
+<script>
+  import "../style/app.css";
+  import Block from "../Block/Block.svelte";
+
+  /**
+   * The width of the text block. Defaults to "body" (max-width: 760px)
+   * @type import("../Block/Block.svelte").BlockWidth
+   */
+  export let width = "body";
+
+  /**
+   * The title of the chart block
+   * @type {string}
+   */
+  export let title;
+  /**
+   * The description of the chart block
+   * @type {string}
+   */
+  export let description;
+
+  /**
+   * The source to include below the chart body - accepts HTML
+   * @type {string}
+   */
+  export let source;
+  /**
+   * The notes line to include below source - accepts HTML
+   * @type {string}
+   */
+  export let notes;
+
+  /**
+   * Optional color override for text
+   * @type {string}
+   */
+  export let color = "var(--color-black)";
+</script>
+
+<Block {width}>
+  <div class="chart-wrapper" style:color>
+    {#if title}
+      <h4 class="chart-title">{title}</h4>
+    {/if}
+    {#if description}
+      <p class="chart-description">{description}</p>
+    {/if}
+    <slot />
+    {#if source || notes}
+      <div class="chart-footer">
+        {#if source}
+          <p><strong>Source:</strong> {@html source}</p>
+        {/if}
+        {#if notes}
+          <p><strong>Notes:</strong> {@html notes}</p>
+        {/if}
+      </div>
+    {/if}
+  </div>
+</Block>
+
+<style>
+  .chart-wrapper {
+    line-height: var(--line-height-normal);
+  }
+  /* chart text */
+  .chart-title {
+    margin: 0 0 var(--spacing-2);
+    font-size: var(--font-size-xl);
+  }
+
+  .chart-description {
+    font-size: var(--font-size-large);
+    margin: 0;
+  }
+
+  .chart-footer p {
+    font-size: var(--font-size-small);
+    margin: 0;
+  }
+  .chart-footer p:not(:last-child) {
+    margin-bottom: var(--spacing-2);
+  }
+
+  @media (min-width: 769px) {
+    .chart-title {
+      font-size: var(--font-size-2xl);
+    }
+  }
+</style>


### PR DESCRIPTION
### What's in this pull request

- [x] New component/feature

### Description
Add a ChartBlock component that wraps any custom visualization with optional text for:
- title
- description
- source
- notes

### Before submitting, please check that you've

- [x] Formatted you code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
