### PR TITLE
Add text overflow ellipsis and right padding to BasicDropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Add right padding and ellipsis on text overflow to BasicDropdown
+
 ## v0.6.0
 
 - Add Theme component and update styles of components accordingly

--- a/src/lib/BasicDropdown/BasicDropdown.svelte
+++ b/src/lib/BasicDropdown/BasicDropdown.svelte
@@ -80,7 +80,7 @@
 
   .dropdown-select {
     color: var(--color-gray-shade-darker);
-    padding: var(--spacing-2) var(--spacing-3);
+    padding: var(--spacing-2) var(--spacing-8) var(--spacing-2) var(--spacing-3);
     font-size: var(--font-size-normal);
     font-family: Lato, helvetica, sans-serif;
     border: 1px solid var(--color-gray-shade-medium);
@@ -93,5 +93,6 @@
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
+    text-overflow: ellipsis;
   }
 </style>


### PR DESCRIPTION
### What's in this pull request

- [x] Bug fix

### Description

Add text overflow ellipsis and right padding to BasicDropdown

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
