### PR TITLE
Turn off Datawrapper interaction events on destroy of component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - Add functionality to remove `placeholder` <option> in BasicDropdown component
+- Turn off interaction events `onDestroy` of DatawrapperIframe
 
 ## v0.6.0
 

--- a/src/lib/DatawrapperIframe/DatawrapperIframe.svelte
+++ b/src/lib/DatawrapperIframe/DatawrapperIframe.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, onDestroy } from "svelte";
   import datawrapper from "./events";
   import datawrapperEventList from "./datawrapper-event-list.json";
 
@@ -48,6 +48,16 @@
       }
     });
   }
+
+  // turn off interaction events on destroy
+  // (prevents multiple events when loading multiple iframes)
+  onDestroy(() => {
+    if (typeof window !== "undefined") {
+      datawrapperEventList.forEach((eventName) => {
+        datawrapper.off(eventName);
+      });
+    }
+  });
 </script>
 
 <iframe


### PR DESCRIPTION
### What's in this pull request

- [x] Other

### Description

Iterates through Datawrapper interaction events and turns them off when component is destroyed. This is useful when switching between multiple iframes and ensuring there is no duplication of events.

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section