### PR TITLE
Re-org Block component docs into component section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Move Block documentation to main component section
+
 ## v0.7.0
 
 - Add right padding and ellipsis on text overflow to BasicDropdown

--- a/src/lib/Block/Block.stories.svelte
+++ b/src/lib/Block/Block.stories.svelte
@@ -2,21 +2,21 @@
   import Block from "./Block.svelte";
 
   export const meta = {
-    title: "Layout/Block",
+    title: "Components/Block",
     description: "A basic building block of a page",
     component: Block,
     tags: ["autodocs"],
     argTypes: {
       width: {
         default: "body",
-        options: ["body", "full"],
+        options: ["body", "wide", "full"],
         control: "select"
       }
     },
     parameters: {
       docs: {
         description: {
-          component: "A basic content block."
+          component: "A basic content block with several width options. This helps when building a page layout if you'd like to place your own components inside a container that aligns with the body well of a typical urban.org layout, a wider block, or a full width block."
         }
       }
     }


### PR DESCRIPTION
### What's in this pull request

- [x] Documentation update

### Description

Just moving around and updating a bit of documentation. The layout Block component is now organized in the main "Components" folder instead of being in its own section.

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
- [x] If this pull request includes a new component or feature, has it been exported from one of the library's entry points?
