### PR TITLE
update language in example docs code blocks to html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Set example code block language to html
+
 ## v0.7.1
 
 - Add Analytics component

--- a/src/docs/BasicPage.docs.mdx
+++ b/src/docs/BasicPage.docs.mdx
@@ -1,10 +1,10 @@
-import { Meta, Canvas } from "@storybook/blocks"
-import * as stories from "./stories/BasicPage.stories.svelte"
+import { Meta, Canvas } from "@storybook/blocks";
+import * as stories from "./stories/BasicPage.stories.svelte";
 
-<Meta title="Examples/BasicPage"/>
+<Meta title="Examples/BasicPage" />
+
 # Basic Page example
 
 Here is an example that pieces together parts of this library into a basic page layout. Example source code is below.
 
-<Canvas of={stories.BasicPage} sourceState="shown"/>
-
+<Canvas of={stories.BasicPage} sourceState="shown" source={{ language: "html" }} />

--- a/src/docs/DatawrapperSwitching.docs.mdx
+++ b/src/docs/DatawrapperSwitching.docs.mdx
@@ -9,8 +9,8 @@ It's useful to switch between Datawrapper iframes. Below, we demonstrate two use
 
 ### Switching with a dropdown
 
-<Canvas of={stories.Dropdown} sourceState="shown" />
+<Canvas of={stories.Dropdown} sourceState="shown" source={{ language: "html" }} />
 
 ### Switching with buttons
 
-<Canvas of={stories.Buttons} sourceState="shown" />
+<Canvas of={stories.Buttons} sourceState="shown" source={{ language: "html" }} />


### PR DESCRIPTION
### What's in this pull request

- [x] Documentation update

### Description

Explicitly setting language to html in example code blocks is much nicer than the default.

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section