### PR TITLE
added case for no projectUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixes package name in documentation
 - Fixes Intro code chunk to be up to date
 - Changes snake_case variables to camelCase
+- Add Navbar case for no projectUrl with story documentation
 
 ## v0.7.1
 

--- a/src/lib/Navbar/Navbar.stories.svelte
+++ b/src/lib/Navbar/Navbar.stories.svelte
@@ -35,7 +35,14 @@
 <Story name="Default" />
 
 <Story
-  name="With title"
+  name="With title, no project link"
+  args={{
+    title: "Project title"
+  }}
+/>
+
+<Story
+  name="With title and project link"
   args={{
     title: "Project title",
     projectUrl: "https://urban.org"
@@ -55,7 +62,7 @@
   name="TPC"
   args={{
     title: "Project title",
-    projectUrl: "https://urban.org",
+    projectUrl: "https://taxpolicycenter.org",
     brand: "tpc"
   }}
 />

--- a/src/lib/Navbar/Navbar.svelte
+++ b/src/lib/Navbar/Navbar.svelte
@@ -12,7 +12,7 @@
    * URL to link to from the title
    * @type {string}
    */
-  export let projectUrl;
+  export let projectUrl = "";
 
   /**
    * Brand to use for the logo
@@ -40,9 +40,13 @@
     </a>
   </div>
   {#if title}
+    {#if projectUrl}
     <a href="{projectUrl}/">
       <p class="nav--page-title">{title}</p>
     </a>
+    {:else}
+    <p class="nav--page-title">{title}</p>
+    {/if}
   {/if}
 </nav>
 


### PR DESCRIPTION
### What's in this pull request

- [x] Bug fix
- [x] Documentation update

Resolves #70 

### Description

Previously, an error was thrown if no `projectUrl` was declared in the component, even though that case was used in the story documentation. I added a default empty string for the `projectUrl` parameter and added a case for if there's a `title` given without that link, along with the story documentation for the same. This fix gives developers more options for how they want to render the component, freestyle.

I also updated the projectUrl for the TPC scenario in the docs to be a link to TPC's website, for kicks.

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
