### PR TITLE
Make BasicDropdown value optionally null 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixes package name in documentation
 - Fixes Intro code chunk to be up to date
 - Changes snake_case variables to camelCase
+- Change BasicDropdown's value prop to accept null
 
 ## v0.7.1
 

--- a/src/lib/BasicDropdown/BasicDropdown.svelte
+++ b/src/lib/BasicDropdown/BasicDropdown.svelte
@@ -11,7 +11,7 @@
 
   /**
    * Binds to the current value for the dropdown (data.value)
-   * @type {string}
+   * @type {string | number | null}
    */
   export let value;
 

--- a/src/lib/BasicDropdown/BasicDropdown.svelte
+++ b/src/lib/BasicDropdown/BasicDropdown.svelte
@@ -11,7 +11,7 @@
 
   /**
    * Binds to the current value for the dropdown (data.value)
-   * @type {string | number | null}
+   * @type {string | null}
    */
   export let value;
 


### PR DESCRIPTION
### What's in this pull request

- [x] Bug fix

### Description

In order to bind a variable (initially set to null) to a dropdown where there is a palceholder (null value) then the prop needs to accept a null value and not just string.

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section