### PR TITLE
Fix: color utils exports

### DIFF
--- a/src/lib/utils/tpcColors.js
+++ b/src/lib/utils/tpcColors.js
@@ -1,20 +1,14 @@
-/**
- * An object representing all of TPC's color palette.
- * @type Record<string, string>
- */
-const colors = {
-  blue_dark: "#174a7c",
-  blue: "#008bb0",
-  blue_shade_light: "#60a1b6",
-  blue_shade_lighter: "#95c0cf",
-  blue_shade_lightest: "#cae0e7",
-  blue_shade_dark: "#1d5669",
-  blue_shade_darker: "#0e2b35",
-  orange: "#f0573e",
-  gray: "#bcbec0",
-  black: "#000000",
-  yellow: "#fcb64b"
-};
+const blue_dark = "#174a7c";
+const blue = "#008bb0";
+const blue_shade_light = "#60a1b6";
+const blue_shade_lighter = "#95c0cf";
+const blue_shade_lightest = "#cae0e7";
+const blue_shade_dark = "#1d5669";
+const blue_shade_darker = "#0e2b35";
+const orange = "#f0573e";
+const gray = "#bcbec0";
+const black = "#000000";
+const yellow = "#fcb64b";
 
 /**
  * Returns a list of 6 sequential blue hues for data visualization based on TPC's style guide
@@ -22,18 +16,28 @@ const colors = {
  */
 function getBlues() {
   const shades = [
-    colors.blue_shade_lightest,
-    colors.blue_shade_lighter,
-    colors.blue_shade_light,
-    colors.blue,
-    colors.blue_shade_dark,
-    colors.blue_shade_darker,
+    blue_shade_lightest,
+    blue_shade_lighter,
+    blue_shade_light,
+    blue,
+    blue_shade_dark,
+    blue_shade_darker,
   ];
   return shades.slice();
 }
 
 
 export default {
-  ...colors,
+  blue_dark,
+  blue,
+  blue_shade_light,
+  blue_shade_lighter,
+  blue_shade_lightest,
+  blue_shade_dark,
+  blue_shade_darker,
+  orange,
+  gray,
+  black,
+  yellow,
   getBlues,
 };

--- a/src/lib/utils/urbanColors.js
+++ b/src/lib/utils/urbanColors.js
@@ -1,67 +1,61 @@
-/**
- * An object representing all of the Urban Institute's color palette.
- * @type Record<string, string>
- */
-const colors = {
-  black: "#000000",
-  white: "#FFFFFF",
-  blue_shade_darkest: "#062635",
-  blue_shade_darker: "#0A4C6A",
-  blue_shade_dark: "#12719E",
-  blue: "#1696D2",
-  blue_shade_medium: "#46ABDB",
-  blue_shade_light: "#73BFE2",
-  blue_shade_lighter: "#A2D4EC",
-  blue_shade_lightest: "#CFE8F3",
-  gray_shade_darkest: "#353535",
-  gray_shade_darker: "#696969",
-  gray_shade_dark: "#9D9D9D",
-  gray: "#D2D2D2",
-  gray_shade_medium: "#DCDBDB",
-  gray_shade_light: "#E3E3E3",
-  gray_shade_lighter: "#ECECEC",
-  gray_shade_lightest: "#F5F5F5",
-  yellow_shade_darkest: "#843215",
-  yellow_shade_darker: "#CA5800",
-  yellow_shade_dark: "#E88E2D",
-  yellow: "#FDBF11",
-  yellow_shade_medium: "#FCCB41",
-  yellow_shade_light: "#FDD870",
-  yellow_shade_lighter: "#FCE39E",
-  yellow_shade_lightest: "#FFF2CF",
-  magenta_shade_darkest: "#351123",
-  magenta_shade_darker: "#761548",
-  magenta_shade_dark: "#af1f6b",
-  magenta: "#EC00BB",
-  magenta_shade_medium: "#E54096",
-  magenta_shade_light: "#E46AA7",
-  magenta_shade_lighter: "#EB99C2",
-  magenta_shade_lightest: "#F5CBDF",
-  green_shade_darkest: "#1A2E19",
-  green_shade_darker: "#2C5C2D",
-  green_shade_dark: "#408941",
-  green: "#55B748",
-  green_shade_medium: "#78C26D",
-  green_shade_light: "#98CF90",
-  green_shade_lighter: "#BCDEB4",
-  green_shade_lightest: "#DCEDD9",
-  red_shade_darkest: "#1A2E19",
-  red_shade_darker: "#6E1614",
-  red_shade_dark: "#A4201D",
-  red: "#DB2B27",
-  red_shade_medium: "#E25552",
-  red_shade_light: "#E9807D",
-  red_shade_lighter: "#F1AAA9",
-  red_shade_lightest: "#F8D5D4",
-  space_gray_shade_darkest: "#0E0C0D",
-  space_gray_shade_darker: "#1A1717",
-  space_gray_shade_dark: "#262223",
-  space_gray_shade_medium_dark: "#332D2F",
-  space_gray: "#5C5859",
-  space_gray_shade_light: "#848081",
-  space_gray_shade_lighter: "#ADABAC",
-  space_gray_shade_lightest: "#D5D5D4"
-};
+const black = "#000000";
+const white = "#FFFFFF";
+const blue_shade_darkest = "#062635";
+const blue_shade_darker = "#0A4C6A";
+const blue_shade_dark = "#12719E";
+const blue = "#1696D2";
+const blue_shade_medium = "#46ABDB";
+const blue_shade_light = "#73BFE2";
+const blue_shade_lighter = "#A2D4EC";
+const blue_shade_lightest = "#CFE8F3";
+const gray_shade_darkest = "#353535";
+const gray_shade_darker = "#696969";
+const gray_shade_dark = "#9D9D9D";
+const gray = "#D2D2D2";
+const gray_shade_medium = "#DCDBDB";
+const gray_shade_light = "#E3E3E3";
+const gray_shade_lighter = "#ECECEC";
+const gray_shade_lightest = "#F5F5F5";
+const yellow_shade_darkest = "#843215";
+const yellow_shade_darker = "#CA5800";
+const yellow_shade_dark = "#E88E2D";
+const yellow = "#FDBF11";
+const yellow_shade_medium = "#FCCB41";
+const yellow_shade_light = "#FDD870";
+const yellow_shade_lighter = "#FCE39E";
+const yellow_shade_lightest = "#FFF2CF";
+const magenta_shade_darkest = "#351123";
+const magenta_shade_darker = "#761548";
+const magenta_shade_dark = "#af1f6b";
+const magenta = "#EC00BB";
+const magenta_shade_medium = "#E54096";
+const magenta_shade_light = "#E46AA7";
+const magenta_shade_lighter = "#EB99C2";
+const magenta_shade_lightest = "#F5CBDF";
+const green_shade_darkest = "#1A2E19";
+const green_shade_darker = "#2C5C2D";
+const green_shade_dark = "#408941";
+const green = "#55B748";
+const green_shade_medium = "#78C26D";
+const green_shade_light = "#98CF90";
+const green_shade_lighter = "#BCDEB4";
+const green_shade_lightest = "#DCEDD9";
+const red_shade_darkest = "#1A2E19";
+const red_shade_darker = "#6E1614";
+const red_shade_dark = "#A4201D";
+const red = "#DB2B27";
+const red_shade_medium = "#E25552";
+const red_shade_light = "#E9807D";
+const red_shade_lighter = "#F1AAA9";
+const red_shade_lightest = "#F8D5D4";
+const space_gray_shade_darkest = "#0E0C0D";
+const space_gray_shade_darker = "#1A1717";
+const space_gray_shade_dark = "#262223";
+const space_gray_shade_medium_dark = "#332D2F";
+const space_gray = "#5C5859";
+const space_gray_shade_light = "#848081";
+const space_gray_shade_lighter = "#ADABAC";
+const space_gray_shade_lightest = "#D5D5D4";
 
 /**
  * Returns a list of 8 sequential blue hues for data visualization based on Urban's style guide
@@ -69,14 +63,14 @@ const colors = {
  */
 function getBlues() {
   const shades = [
-    colors.blue_shade_lightest,
-    colors.blue_shade_lighter,
-    colors.blue_shade_light,
-    colors.blue_shade_medium,
-    colors.blue,
-    colors.blue_shade_dark,
-    colors.blue_shade_darker,
-    colors.blue_shade_darkest
+    blue_shade_lightest,
+    blue_shade_lighter,
+    blue_shade_light,
+    blue_shade_medium,
+    blue,
+    blue_shade_dark,
+    blue_shade_darker,
+    blue_shade_darkest
   ];
   return shades.slice();
 }
@@ -87,14 +81,14 @@ function getBlues() {
  */
 function getMagentas() {
   const shades = [
-    colors.magenta_shade_lightest,
-    colors.magenta_shade_lighter,
-    colors.magenta_shade_light,
-    colors.magenta_shade_medium,
-    colors.magenta,
-    colors.magenta_shade_dark,
-    colors.magenta_shade_darker,
-    colors.magenta_shade_darkest
+    magenta_shade_lightest,
+    magenta_shade_lighter,
+    magenta_shade_light,
+    magenta_shade_medium,
+    magenta,
+    magenta_shade_dark,
+    magenta_shade_darker,
+    magenta_shade_darkest
   ];
   return shades.slice();
 }
@@ -105,14 +99,14 @@ function getMagentas() {
  */
 function getGrays() {
   const shades = [
-    colors.gray_shade_lightest,
-    colors.gray_shade_lighter,
-    colors.gray_shade_light,
-    colors.gray_shade_medium,
-    colors.gray,
-    colors.gray_shade_dark,
-    colors.gray_shade_darker,
-    colors.gray_shade_darkest
+    gray_shade_lightest,
+    gray_shade_lighter,
+    gray_shade_light,
+    gray_shade_medium,
+    gray,
+    gray_shade_dark,
+    gray_shade_darker,
+    gray_shade_darkest
   ];
   return shades.slice();
 }
@@ -123,14 +117,14 @@ function getGrays() {
  */
 function getYellows() {
   const shades = [
-    colors.yellow_shade_lightest,
-    colors.yellow_shade_lighter,
-    colors.yellow_shade_light,
-    colors.yellow_shade_medium,
-    colors.yellow,
-    colors.yellow_shade_dark,
-    colors.yellow_shade_darker,
-    colors.yellow_shade_darkest
+    yellow_shade_lightest,
+    yellow_shade_lighter,
+    yellow_shade_light,
+    yellow_shade_medium,
+    yellow,
+    yellow_shade_dark,
+    yellow_shade_darker,
+    yellow_shade_darkest
   ];
   return shades.slice();
 }
@@ -141,14 +135,14 @@ function getYellows() {
  */
 function getGreens() {
   const shades = [
-    colors.green_shade_lightest,
-    colors.green_shade_lighter,
-    colors.green_shade_light,
-    colors.green_shade_medium,
-    colors.green,
-    colors.green_shade_dark,
-    colors.green_shade_darker,
-    colors.green_shade_darkest
+    green_shade_lightest,
+    green_shade_lighter,
+    green_shade_light,
+    green_shade_medium,
+    green,
+    green_shade_dark,
+    green_shade_darker,
+    green_shade_darkest
   ];
   return shades.slice();
 }
@@ -159,14 +153,14 @@ function getGreens() {
  */
 function getSpaceGrays() {
   const shades = [
-    colors.space_gray_shade_lightest,
-    colors.space_gray_shade_lighter,
-    colors.space_gray_shade_light,
-    colors.space_gray,
-    colors.space_gray_shade_medium_dark,
-    colors.space_gray_shade_dark,
-    colors.space_gray_shade_darker,
-    colors.space_gray_shade_darkest
+    space_gray_shade_lightest,
+    space_gray_shade_lighter,
+    space_gray_shade_light,
+    space_gray,
+    space_gray_shade_medium_dark,
+    space_gray_shade_dark,
+    space_gray_shade_darker,
+    space_gray_shade_darkest
   ];
   return shades.slice();
 }
@@ -177,14 +171,14 @@ function getSpaceGrays() {
  */
 function getReds() {
   const shades = [
-    colors.red_shade_lightest,
-    colors.red_shade_lighter,
-    colors.red_shade_light,
-    colors.red_shade_medium,
-    colors.red,
-    colors.red_shade_dark,
-    colors.red_shade_darker,
-    colors.red_shade_darkest
+    red_shade_lightest,
+    red_shade_lighter,
+    red_shade_light,
+    red_shade_medium,
+    red,
+    red_shade_dark,
+    red_shade_darker,
+    red_shade_darkest
   ];
   return shades.slice();
 }
@@ -195,14 +189,14 @@ function getReds() {
  */
 function getDivergingColors() {
   return [
-    colors.yellow_shade_darker,
-    colors.yellow,
-    colors.yellow_shade_light,
-    colors.yellow_shade_lightest,
-    colors.blue_shade_lightest,
-    colors.blue_shade_light,
-    colors.blue,
-    colors.blue_shade_darker
+    yellow_shade_darker,
+    yellow,
+    yellow_shade_light,
+    yellow_shade_lightest,
+    blue_shade_lightest,
+    blue_shade_light,
+    blue,
+    blue_shade_darker
   ];
 }
 
@@ -216,31 +210,31 @@ function getCategoricalColors(numColors = 6) {
     console.warn(
       "If you need more than 6 colors, you'll need to construct your own palette by using the colors object exported from this module."
     );
-    throw new Error("getCategoricalColors only supports up to 6 colors.");
+    throw new Error("getCategoricalColors only supports up to 6 ");
   }
   if (numColors < 2) {
-    throw new Error("getCategoricalColors must have at least 2 colors.");
+    throw new Error("getCategoricalColors must have at least 2 ");
   }
 
   if (numColors === 2) {
-    return [colors.blue, colors.yellow];
+    return [blue, yellow];
   }
   if (numColors === 3) {
-    return [colors.blue, colors.yellow, colors.black];
+    return [blue, yellow, black];
   }
   if (numColors === 4) {
-    return [colors.blue, colors.yellow, colors.black, colors.magenta];
+    return [blue, yellow, black, magenta];
   }
   if (numColors === 5) {
-    return [colors.blue, colors.yellow, colors.black, colors.magenta, colors.gray];
+    return [blue, yellow, black, magenta, gray];
   }
   return [
-    colors.blue,
-    colors.yellow,
-    colors.magenta,
-    colors.black,
-    colors.gray,
-    colors.blue_shade_light
+    blue,
+    yellow,
+    magenta,
+    black,
+    gray,
+    blue_shade_light
   ];
 }
 
@@ -250,16 +244,73 @@ function getCategoricalColors(numColors = 6) {
  */
 function getMapBlues() {
   return [
-    colors.blue_shade_lightest,
-    colors.blue_shade_light,
-    colors.blue,
-    colors.blue_shade_darker,
-    colors.black
+    blue_shade_lightest,
+    blue_shade_light,
+    blue,
+    blue_shade_darker,
+    black
   ];
 }
 
 export default {
-  ...colors,
+  black,
+  white,
+  blue_shade_darkest,
+  blue_shade_darker,
+  blue_shade_dark,
+  blue,
+  blue_shade_medium,
+  blue_shade_light,
+  blue_shade_lighter,
+  blue_shade_lightest,
+  gray_shade_darkest,
+  gray_shade_darker,
+  gray_shade_dark,
+  gray,
+  gray_shade_medium,
+  gray_shade_light,
+  gray_shade_lighter,
+  gray_shade_lightest,
+  yellow_shade_darkest,
+  yellow_shade_darker,
+  yellow_shade_dark,
+  yellow,
+  yellow_shade_medium,
+  yellow_shade_light,
+  yellow_shade_lighter,
+  yellow_shade_lightest,
+  magenta_shade_darkest,
+  magenta_shade_darker,
+  magenta_shade_dark,
+  magenta,
+  magenta_shade_medium,
+  magenta_shade_light,
+  magenta_shade_lighter,
+  magenta_shade_lightest,
+  green_shade_darkest,
+  green_shade_darker,
+  green_shade_dark,
+  green,
+  green_shade_medium,
+  green_shade_light,
+  green_shade_lighter,
+  green_shade_lightest,
+  red_shade_darkest,
+  red_shade_darker,
+  red_shade_dark,
+  red,
+  red_shade_medium,
+  red_shade_light,
+  red_shade_lighter,
+  red_shade_lightest,
+  space_gray_shade_darkest,
+  space_gray_shade_darker,
+  space_gray_shade_dark,
+  space_gray_shade_medium_dark,
+  space_gray,
+  space_gray_shade_light,
+  space_gray_shade_lighter,
+  space_gray_shade_lightest,
   getBlues,
   getMagentas,
   getGrays,


### PR DESCRIPTION
### What's in this pull request

- [x] Bug fix


### Description

The way that the color utilities exported the base color constants wasn't playing well with type generation. This PR reorgs the exports so that they are recognized by the language server. Fixes #73.

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
- [x] If this pull request includes a new component or feature, has it been exported from one of the library's entry points?
