### PR TITLE
- Add "development" string value to jsdoc in Analytics component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Add "development" string value to jsdoc in Analytics component
+
 ## v0.8.0
 
 - Simplify CSS in Toggle component

--- a/src/lib/Analytics/Analytics.svelte
+++ b/src/lib/Analytics/Analytics.svelte
@@ -11,7 +11,7 @@
       dataviz_title: window.ui_dataviz_config.analytics_title,
       dataviz_target: target,
       dataviz_detail: eventName
-    }
+    };
     if (!DEV) {
       if (typeof window === "undefined" || !window.gtag) return;
       window.gtag("event", "dataviz_click", eventData);
@@ -38,7 +38,7 @@
 
   /**
    * If set to "development", logClickToGA will print debugging info rather than sending events to GA. Set to "production" to send actual events.
-   * @type {string} ["production"]
+   * @type {string} ["production"|"development"]
    */
   export let mode = "production";
 


### PR DESCRIPTION
### What's in this pull request

- [x] Documentation update

### Description

Add "development" string value to jsdoc in Analytics component

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section