### PR TITLE
hotfix: basicdropdown, remove border radius

### DIFF
--- a/src/lib/BasicDropdown/BasicDropdown.svelte
+++ b/src/lib/BasicDropdown/BasicDropdown.svelte
@@ -119,6 +119,7 @@
     -moz-appearance: none;
     appearance: none;
     width: 100%;
+    border-radius: 0 !important;
   }
 
   .dropdown-select.primary {


### PR DESCRIPTION
### What's in this pull request

- [x] Bug fix

### Description

Remove border radius from dropdown, (re: safari applying styles)

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section