### PR TITLE
Fix: remove padding from map zoom control buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # @UrbanInstitute/dataviz-components Changelog
 
 ## Next
+- Fix: Remove padding from ZoomControls on map in mobile Safari
 
 ## v0.10.0
 

--- a/src/lib/maps/SVGMap/ZoomControls.svelte
+++ b/src/lib/maps/SVGMap/ZoomControls.svelte
@@ -118,6 +118,7 @@
     align-items: center;
     justify-content: center;
     cursor: pointer;
+    padding: 0;
   }
 
   .zoom-button:disabled {


### PR DESCRIPTION
### What's in this pull request

- [x] Bug fix

### Description

Fixes bug on mobile Safari where SVG icons did not display properly on ZoomControls

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
- [x] If this pull request includes a new component or feature, has it been exported from one of the library's entry points?
- [x] Does the component dispatch relevant interaction events? (ie: on:click, on:change, etc.)
