### PR TITLE
Patch: add theme's css variable intellisense instructions to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next
 
 - Patch: Run Vitest tests in CI
-- Feature: Add style/theme export
+- Feature: Add style/theme export and instructions on CSS variable intellisense
 
 ## v0.10.1
 

--- a/src/lib/Theme/Theme.docs.mdx
+++ b/src/lib/Theme/Theme.docs.mdx
@@ -19,7 +19,7 @@ You get everything you need out of the box by importing and using these componen
 </script>
 <FontsUrban />
 <Theme>
-  <Button />
+  <button />
 </Theme>
 ```
 
@@ -31,16 +31,16 @@ If you need access to the `<Theme>` component CSS as a global stylesheet, this l
 import "@urbaninstitute/dataviz-components/style/theme";
 ```
 
-## VS Code Intellisense
+## VS Code Intellisense for CSS Variables
 
-In order to get VS Code intellisense for the CSS variables provided by the theme, you can download the [CSS Var Complete](https://marketplace.visualstudio.com/items?itemName=phoenisx.cssvar) and add the following path to the `cssvar.files` extension settings: `node_modules/@urbaninstitute/dataviz-components/dist/style/theme.css`
+In order to get VS Code intellisense for the CSS variables provided by the theme, you can download the [CSS Var Complete](https://marketplace.visualstudio.com/items?itemName=phoenisx.cssvar) and add the following path to the `cssvar.files` extension settings: `node_modules/@urbaninstitute/dataviz-components/dist/style/theme.css`. If you're seeing more options than you'd like, remove `**/*.css` from the setting (added by default).
 
 ## CSS Variables
 
 The CSS variables provided by the theme that can be used in components in this library or your own code are as follows:
 
 <Markdown>
-{`| Variable                       | Value                                                                                         |
+  {`| Variable                       | Value                                                                                         |
 | ------------------------------ | --------------------------------------------------------------------------------------------- |
 | \`--font-family-sans\`           | \`Lato, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"\` |
 | \`--font-family-sans-alt\`       | \`"futura-pt", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"\` |

--- a/src/lib/Theme/Theme.docs.mdx
+++ b/src/lib/Theme/Theme.docs.mdx
@@ -1,5 +1,5 @@
-import * as Stories from "./Theme.stories.svelte"
-import { Meta, Controls, Markdown } from "@storybook/blocks"
+import * as Stories from "./Theme.stories.svelte";
+import { Meta, Controls, Markdown } from "@storybook/blocks";
 
 <Meta title="Theming/Theme" component={Stories.Theme} />
 
@@ -21,7 +21,7 @@ You get everything you need out of the box by importing and using these componen
 <Theme>
   <Button />
 </Theme>
-````
+```
 
 ## Stylesheet import
 
@@ -30,6 +30,10 @@ If you need access to the `<Theme>` component CSS as a global stylesheet, this l
 ```javascript
 import "@urbaninstitute/dataviz-components/style/theme";
 ```
+
+## VS Code Intellisense
+
+In order to get VS Code intellisense for the CSS variables provided by the theme, you can download the [CSS Var Complete](https://marketplace.visualstudio.com/items?itemName=phoenisx.cssvar) and add the following path to the `cssvar.files` extension settings: `node_modules/@urbaninstitute/dataviz-components/dist/style/theme.css`
 
 ## CSS Variables
 

--- a/src/lib/Theme/Theme.docs.mdx
+++ b/src/lib/Theme/Theme.docs.mdx
@@ -19,7 +19,7 @@ You get everything you need out of the box by importing and using these componen
 </script>
 <FontsUrban />
 <Theme>
-  <button />
+  <Button />
 </Theme>
 ```
 
@@ -33,7 +33,11 @@ import "@urbaninstitute/dataviz-components/style/theme";
 
 ## VS Code Intellisense for CSS Variables
 
-In order to get VS Code intellisense for the CSS variables provided by the theme, you can download the [CSS Var Complete](https://marketplace.visualstudio.com/items?itemName=phoenisx.cssvar) and add the following path to the `cssvar.files` extension settings: `node_modules/@urbaninstitute/dataviz-components/dist/style/theme.css`. If you're seeing more options than you'd like, remove `**/*.css` from the setting (added by default).
+In order to get VS Code intellisense for the CSS variables provided by the theme, you can download the [CSS Var Complete extension](https://marketplace.visualstudio.com/items?itemName=phoenisx.cssvar), add path below to the `cssvar.files` extension settings, and restart VS Code extensions.
+
+`node_modules/@urbaninstitute/dataviz-components/dist/style/theme.css`
+
+If you're seeing more options than you'd like, remove `**/*.css` from the setting (added by default).
 
 ## CSS Variables
 


### PR DESCRIPTION
### What's in this pull request

- [x] Documentation update

### Description

Add instructions to `Theme.docs.mdx` on how to reference css variables in intellisense. Original PR: #100 

### Before submitting, please check that you've

- [x] Documented any new components or features
