### PR TITLE
Feature: sourcecode link for components

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,7 +6,8 @@ const config = {
     "@storybook/addon-essentials",
     "@storybook/addon-interactions",
     "@storybook/addon-svelte-csf",
-    "@storybook/addon-a11y"
+    "@storybook/addon-a11y",
+    "@etchteam/storybook-addon-github-link"
   ],
   framework: {
     name: "@storybook/sveltekit",

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -67,6 +67,10 @@ const preview = {
           }
         }
       }
+    },
+    githubLink: {
+      baseURL: "https://github.com/UrbanInstitute/dataviz-components/tree/main/src/lib/",
+      auto: false
     }
   },
   decorators: [() => Theme]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Feature: GitHub source links for components via [@etchteam/storybook-addon-github-link](https://storybook.js.org/addons/@etchteam/storybook-addon-github-link) in storybook docs
+
 ## v0.10.2
 
 - Patch: Run Vitest tests in CI

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "pym.js": "^1.3.2"
       },
       "devDependencies": {
+        "@etchteam/storybook-addon-github-link": "^1.0.1",
         "@storybook/addon-a11y": "^8.0.5",
         "@storybook/addon-essentials": "^8.0.5",
         "@storybook/addon-interactions": "^8.0.5",
@@ -2532,6 +2533,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@etchteam/storybook-addon-github-link": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@etchteam/storybook-addon-github-link/-/storybook-addon-github-link-1.0.1.tgz",
+      "integrity": "sha512-U7VWG3Cq3DUy1txLXtIBX153aVAZmmTzCUnQ4XH3U4Wldg0kEdKdYl/04Yd31Y02EBvRNSmHUxptKxe+KZuTUw==",
+      "dev": true
     },
     "node_modules/@fal-works/esbuild-plugin-global-externals": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "svelte": "^4.0.0"
   },
   "devDependencies": {
+    "@etchteam/storybook-addon-github-link": "^1.0.1",
     "@storybook/addon-a11y": "^8.0.5",
     "@storybook/addon-essentials": "^8.0.5",
     "@storybook/addon-interactions": "^8.0.5",

--- a/src/lib/Analytics/Analytics.stories.svelte
+++ b/src/lib/Analytics/Analytics.stories.svelte
@@ -10,6 +10,9 @@
         description: {
           component: "A component that provides Google Analytics functionality to your page."
         }
+      },
+      githubLink: {
+        url: "/Analytics/Analytics.svelte"
       }
     }
   };
@@ -27,6 +30,6 @@
   name="Default"
   args={{
     title: "Urban Institute dataviz components storybook",
-    mode: "development",
+    mode: "development"
   }}
 />

--- a/src/lib/BasicDropdown/BasicDropdown.stories.svelte
+++ b/src/lib/BasicDropdown/BasicDropdown.stories.svelte
@@ -23,6 +23,9 @@
         description: {
           component: "Basic HTML dropdown adhering to Urban styles."
         }
+      },
+      githubLink: {
+        url: "/BasicDropdown/BasicDropdown.svelte"
       }
     }
   };

--- a/src/lib/Block/Block.stories.svelte
+++ b/src/lib/Block/Block.stories.svelte
@@ -16,8 +16,12 @@
     parameters: {
       docs: {
         description: {
-          component: "A basic content block with several width options. This helps when building a page layout if you'd like to place your own components inside a container that aligns with the body well of a typical urban.org layout, a wider block, or a full width block."
+          component:
+            "A basic content block with several width options. This helps when building a page layout if you'd like to place your own components inside a container that aligns with the body well of a typical urban.org layout, a wider block, or a full width block."
         }
+      },
+      githubLink: {
+        url: "/Block/Block.svelte"
       }
     }
   };

--- a/src/lib/Button/Button.stories.svelte
+++ b/src/lib/Button/Button.stories.svelte
@@ -24,6 +24,9 @@
         description: {
           component: "Basic HTML Button adhering to Urban styles."
         }
+      },
+      githubLink: {
+        url: "/Button/Button.svelte"
       }
     }
   };

--- a/src/lib/ChartBlock/ChartBlock.stories.svelte
+++ b/src/lib/ChartBlock/ChartBlock.stories.svelte
@@ -24,8 +24,12 @@
       },
       docs: {
         description: {
-          component: "A basic wrapper for charts that includes, title, description, source, and notes. The default slot can be used to include any type of content or visualization between the provided text."
+          component:
+            "A basic wrapper for charts that includes, title, description, source, and notes. The default slot can be used to include any type of content or visualization between the provided text."
         }
+      },
+      githubLink: {
+        url: "/ChartBlock/ChartBlock.svelte"
       }
     }
   };
@@ -60,7 +64,12 @@
   args={{ ...chartArgs, color: "#FFFFFF" }}
 />
 <Story name="With a Datawrapper chart" args={{ ...chartArgs, color: "#FFFFFF" }}>
-  <ChartBlock title="Datawrapper chart" description="This is what a Datawrapper looks like inside this component." source="Chart source" notes="Chart notes">
+  <ChartBlock
+    title="Datawrapper chart"
+    description="This is what a Datawrapper looks like inside this component."
+    source="Chart source"
+    notes="Chart notes"
+  >
     <DatawrapperIframe
       title="Datawrapper title"
       ariaLabel="This is an accessible title for the visualization"

--- a/src/lib/DatawrapperIframe/DatawrapperIframe.stories.svelte
+++ b/src/lib/DatawrapperIframe/DatawrapperIframe.stories.svelte
@@ -12,6 +12,9 @@
           component:
             "Datawrapper iframe with <a href='https://developer.datawrapper.de/docs/listening-to-chart-interaction-events' target='_blank'>event dispatching</a> enabled. All interaction events are accessible via <code>on:eventname</code> (<b>no periods</b>) on the `DatawrapperIframe` Svelte component itself. The complete event list and associated descriptions can be found <a href='https://developer.datawrapper.de/docs/listening-to-chart-interaction-events#visualization-events' target='_blank'>here</a>.<br/><br/>Examples of how to setup \"switching\" between Datawrapper charts with a dropdown or button controls can be found <a href='/docs/examples-datawrapper-switching--docs'>in the Examples section here</a>.<br/><br/>In April 2024, the <code>vis.rendered</code> event was added to the Datawrapper event list (per the Urban team's request) in order to track when a visualization had been rendered/painted on the page. This is useful if there is a longer loading visualization (like a large map) and you'd like to indicate to the user that the visualization is still loading.<br><br>The `startrender` event is available via the component's `beforeUpdate()` function in order to track when the iframe starts to load. This can be combined with the `vis.rendered` event to track when the visualization has been rendered/painted on the page in combination with the <a href='/docs/components-loadingwrapper--docs' >LoadingWrapper</a> component."
         }
+      },
+      githubLink: {
+        url: "/DatawrapperIframe/DatawrapperIframe.svelte"
       }
     }
   };

--- a/src/lib/Fonts/Fonts.docs.mdx
+++ b/src/lib/Fonts/Fonts.docs.mdx
@@ -4,6 +4,8 @@ import { Meta } from "@storybook/blocks";
 
 # Font loading
 
+[![github](https://badgen.net/badge/icon/GitHub?icon=github&label)](https://github.com/UrbanInstitute/dataviz-components/tree/b02e4223ae34b4d0c5d4e2b0ef30bde606801806/src/lib/Fonts)
+
 If you need to load the Urban brand fonts in your SvelteKit-powered project, you can use the font components included in this library.
 
 Import and use either `<FontsUrban />` or `<FontsWorkrise />` to add the necessary markup to the `<head>` of you html like so:

--- a/src/lib/HeadingAlt/HeadingAlt.stories.svelte
+++ b/src/lib/HeadingAlt/HeadingAlt.stories.svelte
@@ -11,6 +11,9 @@
         description: {
           component: "Alternate title heading in all caps, useful for h2 tags and lower."
         }
+      },
+      githubLink: {
+        url: "/HeadingAlt/HeadingAlt.svelte"
       }
     }
   };

--- a/src/lib/Headline/Headline.stories.svelte
+++ b/src/lib/Headline/Headline.stories.svelte
@@ -30,8 +30,11 @@
         description: {
           component: "A basic headline component."
         }
+      },
+      githubLink: {
+        url: "/Headline/Headline.svelte"
       }
-    },
+    }
   };
 </script>
 
@@ -39,7 +42,7 @@
   import { Story, Template } from "@storybook/addon-svelte-csf";
   import { Button } from "$lib";
 
-  const hed = "Urban Institute Data Visualization Project Headline"
+  const hed = "Urban Institute Data Visualization Project Headline";
 </script>
 
 <Template let:args>
@@ -62,7 +65,8 @@
     headline: hed,
     date: "January 1, 1968",
     eyebrow: "Data tool",
-    description: "The Urban Institute is a nonprofit research organization that provides data and evidence to help advance upward mobility and equity.",
+    description:
+      "The Urban Institute is a nonprofit research organization that provides data and evidence to help advance upward mobility and equity.",
     shareUrl: "https://urban.org"
   }}
 />
@@ -101,7 +105,7 @@
   args={{
     headline: hed,
     date: "January 1, 1968",
-    eyebrow: "Data tool",
+    eyebrow: "Data tool"
   }}
 />
 
@@ -114,21 +118,29 @@
     eyebrow: "Data tool",
     shareUrl: "https://urban.org",
     variant: "light"
-  }}/>
+  }}
+/>
 
 <Story name="With custom slots">
-  <Headline  shareUrl="https://urban.org">
+  <Headline shareUrl="https://urban.org">
     <div slot="eyebrow">
-      <img src="urban-logo.svg" alt="An Urban institute logo" width="120px"/>
+      <img src="urban-logo.svg" alt="An Urban institute logo" width="120px" />
     </div>
-    <h1 style="color: var(--color-blue); text-transform: uppercase; font-weight: var(--font-weight-bold)" slot="headline">Custom headline slot</h1>
+    <h1
+      style="color: var(--color-blue); text-transform: uppercase; font-weight: var(--font-weight-bold)"
+      slot="headline"
+    >
+      Custom headline slot
+    </h1>
     <div slot="description">
       <p>This is a custom description slot</p>
     </div>
     <p slot="date">Custom date slot: January 1, 1968</p>
     <div slot="extra">
       <Button>Extra slot</Button>
-      <p style="font-size: var(--font-size-small); color: var(--color-gray-darker)">(Custom button)</p>
+      <p style="font-size: var(--font-size-small); color: var(--color-gray-darker)">
+        (Custom button)
+      </p>
     </div>
   </Headline>
 </Story>

--- a/src/lib/LoadingWrapper/LoadingWrapper.stories.svelte
+++ b/src/lib/LoadingWrapper/LoadingWrapper.stories.svelte
@@ -15,6 +15,9 @@
           component:
             'Wrapper to display a loading spinner graphic while content is loading. Exposes `setChildLoading()` and `setChildLoaded()` to be used by children as an alternative method of setting `isChildLoading` boolean. Accepts an alternative graphic for the "graphic" named slot.'
         }
+      },
+      githubLink: {
+        url: "/LoadingWrapper/LoadingWrapper.svelte"
       }
     }
   };

--- a/src/lib/LogoTPCBadge/LogoTPCBadge.stories.svelte
+++ b/src/lib/LogoTPCBadge/LogoTPCBadge.stories.svelte
@@ -11,6 +11,9 @@
         description: {
           component: "Tax Policy Center logo in square badge format."
         }
+      },
+      githubLink: {
+        url: "/LogoTPCBadge/LogoTPCBadge.svelte"
       }
     }
   };

--- a/src/lib/LogoUrban/LogoUrban.stories.svelte
+++ b/src/lib/LogoUrban/LogoUrban.stories.svelte
@@ -24,6 +24,9 @@
         description: {
           component: "Urban Institute logo in full width format."
         }
+      },
+      githubLink: {
+        url: "/LogoUrban/LogoUrban.svelte"
       }
     }
   };

--- a/src/lib/LogoUrbanAnimated/LogoUrbanAnimated.stories.svelte
+++ b/src/lib/LogoUrbanAnimated/LogoUrbanAnimated.stories.svelte
@@ -11,6 +11,9 @@
         description: {
           component: "An animated Urban Institute logo icon"
         }
+      },
+      githubLink: {
+        url: "/LogoUrbanAnimated/LogoUrbanAnimated.svelte"
       }
     }
   };

--- a/src/lib/LogoUrbanBadge/LogoUrbanBadge.stories.svelte
+++ b/src/lib/LogoUrbanBadge/LogoUrbanBadge.stories.svelte
@@ -11,6 +11,9 @@
         description: {
           component: "Urban Institute logo in square badge format."
         }
+      },
+      githubLink: {
+        url: "/LogoUrbanBadge/LogoUrbanBadge.svelte"
       }
     }
   };

--- a/src/lib/LogoUrbanWide/LogoUrbanWide.stories.svelte
+++ b/src/lib/LogoUrbanWide/LogoUrbanWide.stories.svelte
@@ -24,6 +24,9 @@
         description: {
           component: "Urban Institute logo in wide format."
         }
+      },
+      githubLink: {
+        url: "/LogoUrbanWide/LogoUrbanWide.svelte"
       }
     }
   };

--- a/src/lib/Meta/Meta.stories.svelte
+++ b/src/lib/Meta/Meta.stories.svelte
@@ -20,8 +20,12 @@
     parameters: {
       docs: {
         description: {
-          component: "This component uses Svelt's built-in `<svelte:head>` component to include important metadata for your HTML page."
+          component:
+            "This component uses Svelt's built-in `<svelte:head>` component to include important metadata for your HTML page."
         }
+      },
+      githubLink: {
+        url: "/Meta/Meta.svelte"
       }
     }
   };
@@ -35,13 +39,15 @@
   <Meta />
 </Template>
 
-<Story name="Default" args={{
-  title: "",
-  description: "",
-  url: "",
-  siteName: "Urban Institute",
-  authors: ["Author Name", "Author Name"],
-  keywords: ["keyword1", "keyword2"],
-  socialImage: ""
-}}>Nothing to see here</Story>
-
+<Story
+  name="Default"
+  args={{
+    title: "",
+    description: "",
+    url: "",
+    siteName: "Urban Institute",
+    authors: ["Author Name", "Author Name"],
+    keywords: ["keyword1", "keyword2"],
+    socialImage: ""
+  }}>Nothing to see here</Story
+>

--- a/src/lib/Navbar/Navbar.stories.svelte
+++ b/src/lib/Navbar/Navbar.stories.svelte
@@ -19,6 +19,9 @@
           component:
             "Full width navigation bar for top of page. Includes <code>brand</code> and <code>sticky</code> properties for Urban/TPC logo and absolute position controls respectively."
         }
+      },
+      githubLink: {
+        url: "/Navbar/Navbar.svelte"
       }
     }
   };

--- a/src/lib/ProjectCredits/ProjectCredits.stories.svelte
+++ b/src/lib/ProjectCredits/ProjectCredits.stories.svelte
@@ -11,6 +11,9 @@
         description: {
           component: "A block for project credits."
         }
+      },
+      githubLink: {
+        url: "/ProjectCredits/ProjectCredits.svelte"
       }
     }
   };

--- a/src/lib/Pym/PymChild.stories.svelte
+++ b/src/lib/Pym/PymChild.stories.svelte
@@ -10,6 +10,9 @@
         description: {
           component: "A basic headline component."
         }
+      },
+      githubLink: {
+        url: "/Pym/PymChild.svelte"
       }
     }
   };

--- a/src/lib/Pym/pymChildStore.docs.mdx
+++ b/src/lib/Pym/pymChildStore.docs.mdx
@@ -4,6 +4,8 @@ import { Meta } from "@storybook/blocks";
 
 # pymChildStore
 
+[![github](https://badgen.net/badge/icon/GitHub?icon=github&label)](https://github.com/UrbanInstitute/dataviz-components/blob/main/src/lib/Pym/stores.js)
+
 A Svelte store that exposes a Pym.js child instance. Used in conjuction with the `<PymChild />` component.
 
 [Read more about how to use the PymChild component here](/docs/components-pymchild--docs).

--- a/src/lib/ReturnTop/ReturnTop.stories.svelte
+++ b/src/lib/ReturnTop/ReturnTop.stories.svelte
@@ -11,6 +11,9 @@
         description: {
           component: "A button for moving the browser to a specified element ID."
         }
+      },
+      githubLink: {
+        url: "/ReturnTop/ReturnTop.svelte"
       }
     }
   };

--- a/src/lib/Scorecard/Scorecard.stories.svelte
+++ b/src/lib/Scorecard/Scorecard.stories.svelte
@@ -12,6 +12,9 @@
           component:
             "Scorecard element, which displays a value and a label, originally developed for <a href='https://www.urban.org/policy-centers/center-labor-human-services-and-population/projects/apprenticeship-support' target='_blank'>this project</a>."
         }
+      },
+      githubLink: {
+        url: "/Scorecard/Scorecard.svelte"
       }
     }
   };

--- a/src/lib/Scrolly/Scrolly.stories.svelte
+++ b/src/lib/Scrolly/Scrolly.stories.svelte
@@ -18,6 +18,11 @@
         options: ["center", "left", "right"],
         control: { type: "select" }
       }
+    },
+    parameters: {
+      githubLink: {
+        url: "/Scrolly/Scrolly.svelte"
+      }
     }
   };
 </script>

--- a/src/lib/SectionBreak/SectionBreak.stories.svelte
+++ b/src/lib/SectionBreak/SectionBreak.stories.svelte
@@ -12,6 +12,9 @@
           component:
             "Section break element that includes a number, a subhead and a horizontal rule."
         }
+      },
+      githubLink: {
+        url: "/SectionBreak/SectionBreak.svelte"
       }
     }
   };

--- a/src/lib/SocialShare/SocialShare.stories.svelte
+++ b/src/lib/SocialShare/SocialShare.stories.svelte
@@ -29,6 +29,9 @@
         description: {
           component: "Social share icons, available in light or dark mode."
         }
+      },
+      githubLink: {
+        url: "/SocialShare/SocialShare.svelte"
       }
     }
   };

--- a/src/lib/TextBlock/TextBlock.stories.svelte
+++ b/src/lib/TextBlock/TextBlock.stories.svelte
@@ -30,6 +30,9 @@
         description: {
           component: "A basic text block."
         }
+      },
+      githubLink: {
+        url: "/TextBlock/TextBlock.svelte"
       }
     }
   };

--- a/src/lib/Theme/Theme.docs.mdx
+++ b/src/lib/Theme/Theme.docs.mdx
@@ -5,6 +5,8 @@ import { Meta, Controls, Markdown } from "@storybook/blocks";
 
 # Theme
 
+[![github](https://badgen.net/badge/icon/GitHub?icon=github&label)](https://github.com/UrbanInstitute/dataviz-components/blob/main/src/lib/Theme/Theme.svelte)
+
 A theme wrapper that provides shared styles for children components. These styles are primarily made up of a series of CSS variables that represent Urban's design system. They also includes some default typographic styling applied to html headings. Components in this library make use of these variables and styles and expect them to be defined, and won't display correctly outside of a parent `<Theme />` component.
 
 All of the `Theme` styles are scoped and won't be applied to content outside of the `<Theme />` itself.
@@ -19,7 +21,7 @@ You get everything you need out of the box by importing and using these componen
 </script>
 <FontsUrban />
 <Theme>
-  <Button />
+  <button />
 </Theme>
 ```
 

--- a/src/lib/Theme/Theme.docs.mdx
+++ b/src/lib/Theme/Theme.docs.mdx
@@ -21,7 +21,7 @@ You get everything you need out of the box by importing and using these componen
 </script>
 <FontsUrban />
 <Theme>
-  <button />
+  <Button />
 </Theme>
 ```
 

--- a/src/lib/Theme/Theme.stories.svelte
+++ b/src/lib/Theme/Theme.stories.svelte
@@ -15,7 +15,6 @@
       slot_default: {
         control: { type: "text" }
       }
-          
     },
     parameters: {
       backgrounds: {
@@ -27,8 +26,12 @@
       },
       docs: {
         description: {
-          component: "A theme wrapper that provides styles for children components. All of the components in this library rely on CSS provided by this <Theme> component. If you are working on a project that depends on this library, you should probably wrap your entire page inside of a `<Theme></Theme>`. If you are pulling in just a component or two to a project that otherwise doesn't use this library, you'll want to wrap those components directly in a `<Theme>`.\n\n```html\n<Theme>\n  <ChildComponent />\n  <ChildComponent />\n</Theme>\n```"
+          component:
+            "A theme wrapper that provides styles for children components. All of the components in this library rely on CSS provided by this <Theme> component. If you are working on a project that depends on this library, you should probably wrap your entire page inside of a `<Theme></Theme>`. If you are pulling in just a component or two to a project that otherwise doesn't use this library, you'll want to wrap those components directly in a `<Theme>`.\n\n```html\n<Theme>\n  <ChildComponent />\n  <ChildComponent />\n</Theme>\n```"
         }
+      },
+      githubLink: {
+        url: "/Theme/Theme.svelte"
       }
     }
   };
@@ -39,8 +42,7 @@
 </script>
 
 <Template let:args>
-  <Theme/>
+  <Theme />
 </Template>
 
 <Story name="Default" />
-

--- a/src/lib/Toggle/Toggle.stories.svelte
+++ b/src/lib/Toggle/Toggle.stories.svelte
@@ -20,6 +20,9 @@
         description: {
           component: "Toggle component adhering to Urban styles."
         }
+      },
+      githubLink: {
+        url: "/Toggle/Toggle.svelte"
       }
     }
   };

--- a/src/lib/Tooltip/Tooltip.stories.svelte
+++ b/src/lib/Tooltip/Tooltip.stories.svelte
@@ -34,6 +34,9 @@
         description: {
           component: "A basic tooltip."
         }
+      },
+      githubLink: {
+        url: "/Tooltip/Tooltip.svelte"
       }
     }
   };
@@ -64,11 +67,16 @@
 </script>
 
 <Template let:args>
-  <div class="wrapper" style="background: var(--color-gray-shade-lighter); width: 100%; height: 300px; display: grid; place-content: center;" on:mousemove={handleMousemove} on:mouseout={handleMouseout}>
+  <div
+    class="wrapper"
+    style="background: var(--color-gray-shade-lighter); width: 100%; height: 300px; display: grid; place-content: center;"
+    on:mousemove={handleMousemove}
+    on:mouseout={handleMouseout}
+  >
     <p>Hover me to see tooltip</p>
   </div>
   {#if tooltipX && tooltipY}
-  <Tooltip {...args} x={tooltipX} y={tooltipY}>{args.content || "This is a tooltip"}</Tooltip>
+    <Tooltip {...args} x={tooltipX} y={tooltipY}>{args.content || "This is a tooltip"}</Tooltip>
   {/if}
 </Template>
 
@@ -91,7 +99,11 @@
 />
 
 <Story name="Custom HTML">
-  <div class="wrapper" style="background: var(--color-gray-shade-lighter); width: 100%; height: 300px; display: grid; place-content: center;" on:mousemove={handleMousemove}>
+  <div
+    class="wrapper"
+    style="background: var(--color-gray-shade-lighter); width: 100%; height: 300px; display: grid; place-content: center;"
+    on:mousemove={handleMousemove}
+  >
     <p>Hover me to see tooltip</p>
   </div>
   {#if tooltipX && tooltipY}
@@ -122,12 +134,12 @@
   >
     <p>Hover me to see tooltip</p>
     {#if tooltipX && tooltipY}
-    <Tooltip
-      content="This tooltip is contained by parent"
-      containParent
-      x={tooltipX}
-      y={tooltipY}
-    />
+      <Tooltip
+        content="This tooltip is contained by parent"
+        containParent
+        x={tooltipX}
+        y={tooltipY}
+      />
     {/if}
   </div>
 </Story>
@@ -142,12 +154,17 @@
     </div>
   </div>
   {#if showPinned}
-    <Tooltip elOffset={5} el={pinEl} >This tooltip is pinned to an existing element</Tooltip>
+    <Tooltip elOffset={5} el={pinEl}>This tooltip is pinned to an existing element</Tooltip>
   {/if}
 </Story>
 
 <Story name="Tooltip override">
-  <div class="wrapper" style="background: var(--color-gray-shade-lighter); width: 100%; height: 300px; display: grid; place-content: center;" on:mousemove={handleMousemove} on:mouseout={handleMouseout}>
+  <div
+    class="wrapper"
+    style="background: var(--color-gray-shade-lighter); width: 100%; height: 300px; display: grid; place-content: center;"
+    on:mousemove={handleMousemove}
+    on:mouseout={handleMouseout}
+  >
     <p>Hover me to see tooltip</p>
   </div>
   {#if tooltipX && tooltipY}

--- a/src/lib/actions/resizeObserver.docs.mdx
+++ b/src/lib/actions/resizeObserver.docs.mdx
@@ -4,6 +4,8 @@ import { Meta } from "@storybook/blocks";
 
 # resizeObserver action
 
+[![github](https://badgen.net/badge/icon/GitHub?icon=github&label)](https://github.com/UrbanInstitute/dataviz-components/blob/main/src/lib/actions/resizeObserver.js)
+
 An action you can use to easily to check when a DOM element's dimensions change using the Resize Observer API. Sometimes is more efficient and less bug prone than Svelte's built-in `bind:clientWidth` approach. This may change when [Svelte 5 switches to using resize observer instead of iframes under the hood](https://github.com/sveltejs/svelte/issues/7583#issuecomment-1905763916).
 
 ## Usage
@@ -19,4 +21,3 @@ An action you can use to easily to check when a DOM element's dimensions change 
   My width is: {width}
 </div>
 ```
-

--- a/src/lib/maps/ColorLegend/ColorLegend.stories.svelte
+++ b/src/lib/maps/ColorLegend/ColorLegend.stories.svelte
@@ -39,6 +39,9 @@
         description: {
           component: "This component generates a color legend based on a D3 scale."
         }
+      },
+      githubLink: {
+        url: "/maps/ColorLegend/ColorLegend.svelte"
       }
     }
   };
@@ -129,8 +132,20 @@
   name="Ordinal scale with buckets"
   args={{
     scale: scaleOrdinal(
-      ["$0 to $20,000", "$20,000 to $50,000", "$50,000 to $75,000", "$75,000 to $100,000", "$100,000 or more"],
-      [urbanColors.green_shade_lightest, urbanColors.green_shade_lighter, urbanColors.green, urbanColors.green_shade_dark, urbanColors.green_shade_darkest]
+      [
+        "$0 to $20,000",
+        "$20,000 to $50,000",
+        "$50,000 to $75,000",
+        "$75,000 to $100,000",
+        "$100,000 or more"
+      ],
+      [
+        urbanColors.green_shade_lightest,
+        urbanColors.green_shade_lighter,
+        urbanColors.green,
+        urbanColors.green_shade_dark,
+        urbanColors.green_shade_darkest
+      ]
     )
   }}
 />
@@ -160,10 +175,22 @@
   name="Ordinal scale swatches with buckets"
   args={{
     scale: scaleOrdinal(
-      ["$0 to $20,000", "$20,000 to $50,000", "$50,000 to $75,000", "$75,000 to $100,000", "$100,000 or more"],
-      [urbanColors.green_shade_lightest, urbanColors.green_shade_lighter, urbanColors.green, urbanColors.green_shade_dark, urbanColors.green_shade_darkest]
+      [
+        "$0 to $20,000",
+        "$20,000 to $50,000",
+        "$50,000 to $75,000",
+        "$75,000 to $100,000",
+        "$100,000 or more"
+      ],
+      [
+        urbanColors.green_shade_lightest,
+        urbanColors.green_shade_lighter,
+        urbanColors.green,
+        urbanColors.green_shade_dark,
+        urbanColors.green_shade_darkest
+      ]
     ),
     swatch: true,
-    swatchLayout: "column",
+    swatchLayout: "column"
   }}
 />

--- a/src/lib/maps/SVGLabelLayer/SVGLabelLayer.stories.svelte
+++ b/src/lib/maps/SVGLabelLayer/SVGLabelLayer.stories.svelte
@@ -16,6 +16,9 @@
         description: {
           component: docs
         }
+      },
+      githubLink: {
+        url: "/maps/SVGLabelLayer/SVGLabelLayer.svelte"
       }
     }
   };
@@ -87,6 +90,7 @@
       on:click={clickHandler}
       on:mouseout={mouseoutHandler}
       on:mousemove={mousemoveHandler}
-    ><svelte:fragment let:props>{props.STUSPS}</svelte:fragment></SVGLabelLayer>
+      ><svelte:fragment let:props>{props.STUSPS}</svelte:fragment></SVGLabelLayer
+    >
   </SVGMap>
 </Story>

--- a/src/lib/maps/SVGMap/SVGMap.stories.svelte
+++ b/src/lib/maps/SVGMap/SVGMap.stories.svelte
@@ -17,6 +17,11 @@
         control: "select",
         options: ["no", "yes", "ctrl"]
       }
+    },
+    parameters: {
+      githubLink: {
+        url: "/maps/SVGMap/SVGMap.svelte"
+      }
     }
   };
 </script>

--- a/src/lib/maps/SVGPointLayer/SVGPointLayer.stories.svelte
+++ b/src/lib/maps/SVGPointLayer/SVGPointLayer.stories.svelte
@@ -17,6 +17,9 @@
         description: {
           component: docs
         }
+      },
+      githubLink: {
+        url: "/maps/SVGPointLayer/SVGPointLayer.svelte"
       }
     }
   };

--- a/src/lib/maps/SVGPolygonLayer/SVGPolygonLayer.stories.svelte
+++ b/src/lib/maps/SVGPolygonLayer/SVGPolygonLayer.stories.svelte
@@ -17,6 +17,9 @@
         description: {
           component: docs
         }
+      },
+      githubLink: {
+        url: "/maps/SVGPolygonLayer/SVGPolygonLayer.svelte"
       }
     }
   };

--- a/src/lib/stores/reducedMotion.docs.mdx
+++ b/src/lib/stores/reducedMotion.docs.mdx
@@ -4,6 +4,8 @@ import { Meta } from "@storybook/blocks";
 
 # prefers-reduced-motion Svelte Store
 
+[![github](https://badgen.net/badge/icon/GitHub?icon=github&label)](https://github.com/UrbanInstitute/dataviz-components/blob/main/src/lib/stores/reducedMotion.js)
+
 A Svelte store that tracks the user's preference for reduced motion, adapted from [Geoff Rich's Accessible Svelte Transitions article](https://geoffrich.net/posts/accessible-svelte-transitions/).
 
 Sometimes users may turn on "prefers-reduced-motion" in their accessibility settings. If this is this is the case, they expect to see no animations or transitions. This store uses `window.matchMedia()` to track the user's preference for reduced motion and can be used for conditional rendering.

--- a/src/lib/utils/TPCColors.docs.mdx
+++ b/src/lib/utils/TPCColors.docs.mdx
@@ -5,6 +5,8 @@ import { tpcColors } from "$lib/utils";
 
 # Colors
 
+[![github](https://badgen.net/badge/icon/GitHub?icon=github&label)](https://github.com/UrbanInstitute/dataviz-components/blob/main/src/lib/utils/tpcColors.js)
+
 The colors utility module provides easy access to the Tax Policy Center's brand colors. For best practices on selecting colors for data visualizations, see the [Tax Policy Center data visualizaton styleguide](https://apps.urban.org/tpc-styleguide/public.html).
 
 To use these, utilities, import the module like so:
@@ -31,7 +33,6 @@ import { tpcColors } from "@urbaninstitute/dataviz-components/utils";
 
 </ColorPalette>
 
-
 Any color can be used directly from the `tpcColors` object:
 
 ```js
@@ -42,23 +43,17 @@ const blue = tpcColors.blue;
 const yellow = tpcColors.yellow;
 ```
 
-
 ## Color shades
 
 TPC Blue has an array of 6 shades for sequential usage.
 
-
 <ColorPalette>
-  <ColorItem
-    title="Blue shades"
-     subtitle=""
-     colors={tpcColors.getBlues()}
-  />
+  <ColorItem title="Blue shades" subtitle="" colors={tpcColors.getBlues()} />
 </ColorPalette>
 
 Usage:
+
 ```js
 // returns ["#cae0e7","#95c0cf","#60a1b6","#008bb0","#1d5669","#0e2b35"]
 tpcColors.getBlues();
 ```
-

--- a/src/lib/utils/UrbanColors.docs.mdx
+++ b/src/lib/utils/UrbanColors.docs.mdx
@@ -5,6 +5,8 @@ import { urbanColors } from "$lib/utils";
 
 # Colors
 
+[![github](https://badgen.net/badge/icon/GitHub?icon=github&label)](https://github.com/UrbanInstitute/dataviz-components/blob/main/src/lib/utils/urbanColors.js)
+
 The colors utility module provides easy access to the Urban Institute's brand colors. For best practices on selecting colors for data visualizations, see the [Urban Institute Data Visualizaton Styleguide](https://urbaninstitute.github.io/graphics-styleguide/#color).
 
 To use these, utilities, import the module like so:
@@ -33,7 +35,6 @@ import { urbanColors } from "@urbaninstitute/dataviz-components/utils";
 
 </ColorPalette>
 
-
 Any color can be used directly from the `urbanColors` object:
 
 ```js
@@ -44,158 +45,140 @@ const blue = urbanColors.blue;
 const magenta = urbanColors.magenta;
 ```
 
-
 ## Color shades
 
 Each of Urban's primary colors also comes in a range of different shades. These can be useful for different data visualization scenarios.
 
-
 <ColorPalette>
-  <ColorItem
-    title="Blue shades"
-     subtitle=""
-     colors={urbanColors.getBlues()}
-  />
+  <ColorItem title="Blue shades" subtitle="" colors={urbanColors.getBlues()} />
 </ColorPalette>
 
 Usage:
+
 ```js
 urbanColors.getBlues();
 ```
 
 Color values:
+
 ```js
-[ "#CFE8F3", "#A2D4EC", "#73BFE2", "#46ABDB", "#1696D2", "#12719E", "#0A4C6A", "#062635" ]
+["#CFE8F3", "#A2D4EC", "#73BFE2", "#46ABDB", "#1696D2", "#12719E", "#0A4C6A", "#062635"];
 ```
 
 <ColorPalette>
-  <ColorItem
-    title="Gray shades"
-     subtitle=""
-     colors={urbanColors.getGrays()}
-  />
+  <ColorItem title="Gray shades" subtitle="" colors={urbanColors.getGrays()} />
 </ColorPalette>
 
 Usage:
+
 ```js
 urbanColors.getGrays();
 ```
 
 Color values:
+
 ```js
-[ "#F5F5F5", "#ECECEC", "#E3E3E3", "#DCDBDB", "#D2D2D2", "#9D9D9D", "#696969", "#353535" ]
+["#F5F5F5", "#ECECEC", "#E3E3E3", "#DCDBDB", "#D2D2D2", "#9D9D9D", "#696969", "#353535"];
 ```
 
 <ColorPalette>
-  <ColorItem
-    title="Yellow shades"
-     subtitle=""
-     colors={urbanColors.getYellows()}
-  />
+  <ColorItem title="Yellow shades" subtitle="" colors={urbanColors.getYellows()} />
 </ColorPalette>
 
 Usage:
+
 ```js
 urbanColors.getYellows();
 ```
 
 Color values:
+
 ```js
-[ "#FFF2CF", "#FCE39E", "#FDD870", "#FCCB41", "#FDBF11", "#E88E2D", "#CA5800", "#843215" ]
+["#FFF2CF", "#FCE39E", "#FDD870", "#FCCB41", "#FDBF11", "#E88E2D", "#CA5800", "#843215"];
 ```
 
 <ColorPalette>
-  <ColorItem
-    title="Magenta shades"
-     subtitle=""
-     colors={urbanColors.getMagentas()}
-  />
+  <ColorItem title="Magenta shades" subtitle="" colors={urbanColors.getMagentas()} />
 </ColorPalette>
 
 Usage:
+
 ```js
 urbanColors.getMagentas();
 ```
+
 Color values:
+
 ```js
-[ "#F5CBDF", "#EB99C2", "#E46AA7", "#E54096", "#EC00BB", "#af1f6b", "#761548", "#351123" ]
+["#F5CBDF", "#EB99C2", "#E46AA7", "#E54096", "#EC00BB", "#af1f6b", "#761548", "#351123"];
 ```
 
 <ColorPalette>
-  <ColorItem
-    title="Green shades"
-     subtitle=""
-     colors={urbanColors.getGreens()}
-  />
+  <ColorItem title="Green shades" subtitle="" colors={urbanColors.getGreens()} />
 </ColorPalette>
 
 Usage:
+
 ```js
 urbanColors.getGreens();
 ```
 
 Color values:
+
 ```js
-[ "#DCEDD9", "#BCDEB4", "#98CF90", "#78C26D", "#55B748", "#408941", "#2C5C2D", "#1A2E19" ]
+["#DCEDD9", "#BCDEB4", "#98CF90", "#78C26D", "#55B748", "#408941", "#2C5C2D", "#1A2E19"];
 ```
 
 <ColorPalette>
-  <ColorItem
-    title="Space gray shades"
-     subtitle=""
-     colors={urbanColors.getSpaceGrays()}
-  />
+  <ColorItem title="Space gray shades" subtitle="" colors={urbanColors.getSpaceGrays()} />
 </ColorPalette>
 
 Usage:
+
 ```js
 urbanColors.getSpaceGrays();
 ```
 
 Color values:
+
 ```js
-[ "#D5D5D4", "#ADABAC", "#848081", "#5C5859", "#332D2F", "#262223", "#1A1717", "#0E0C0D" ]
+["#D5D5D4", "#ADABAC", "#848081", "#5C5859", "#332D2F", "#262223", "#1A1717", "#0E0C0D"];
 ```
 
 <ColorPalette>
-  <ColorItem
-    title="Red shades"
-     subtitle=""
-     colors={urbanColors.getReds()}
-  />
+  <ColorItem title="Red shades" subtitle="" colors={urbanColors.getReds()} />
 </ColorPalette>
 
 Usage:
+
 ```js
 urbanColors.getReds();
 ```
 
 Color values:
+
 ```js
-[ "#F8D5D4", "#F1AAA9", "#E9807D", "#E25552", "#DB2B27", "#A4201D", "#6E1614", "#1A2E19" ]
+["#F8D5D4", "#F1AAA9", "#E9807D", "#E25552", "#DB2B27", "#A4201D", "#6E1614", "#1A2E19"];
 ```
 
 ## DataViz Helpers
 
 Below are a few helper functions to generate some useful default color palettes.
 
-
 <ColorPalette>
-  <ColorItem
-    title="Categorical colors"
-     subtitle=""
-     colors={urbanColors.getCategoricalColors()}
-  />
+  <ColorItem title="Categorical colors" subtitle="" colors={urbanColors.getCategoricalColors()} />
 </ColorPalette>
 
 Usage:
+
 ```js
 urbanColors.getCategoricalColors();
 ```
 
 Color values:
+
 ```js
-[ "#1696D2", "#FDBF11", "#EC00BB", "#000000", "#D2D2D2", "#73BFE2"]
+["#1696D2", "#FDBF11", "#EC00BB", "#000000", "#D2D2D2", "#73BFE2"];
 ```
 
 This function generates a 6 color palette by default, but you can specify any number between 2 and 6.
@@ -203,73 +186,81 @@ This function generates a 6 color palette by default, but you can specify any nu
 <ColorPalette>
   <ColorItem
     title="Categorical colors"
-     subtitle="2 colors"
-     colors={urbanColors.getCategoricalColors(2)}
+    subtitle="2 colors"
+    colors={urbanColors.getCategoricalColors(2)}
   />
 </ColorPalette>
 
 Usage:
+
 ```js
 urbanColors.getCategoricalColors(2);
 ```
 
 Color values:
+
 ```js
-[ "#1696D2", "#FDBF11" ]
+["#1696D2", "#FDBF11"];
 ```
 
 <ColorPalette>
   <ColorItem
     title="Categorical colors"
-     subtitle="3 colors"
-     colors={urbanColors.getCategoricalColors(3)}
+    subtitle="3 colors"
+    colors={urbanColors.getCategoricalColors(3)}
   />
 </ColorPalette>
 
 Usage:
+
 ```js
 urbanColors.getCategoricalColors(3);
 ```
 
 Color values:
+
 ```js
-[ "#1696D2", "#FDBF11", "#000000" ]
+["#1696D2", "#FDBF11", "#000000"];
 ```
 
 <ColorPalette>
   <ColorItem
     title="Categorical colors"
-     subtitle="4 colors"
-     colors={urbanColors.getCategoricalColors(4)}
+    subtitle="4 colors"
+    colors={urbanColors.getCategoricalColors(4)}
   />
 </ColorPalette>
 
 Usage:
+
 ```js
 urbanColors.getCategoricalColors(4);
 ```
 
 Color values:
+
 ```js
-[ "#1696D2", "#FDBF11", "#000000", "#EC00BB" ]
+["#1696D2", "#FDBF11", "#000000", "#EC00BB"];
 ```
 
 <ColorPalette>
   <ColorItem
     title="Categorical colors"
-     subtitle="5 colors"
-     colors={urbanColors.getCategoricalColors(5)}
+    subtitle="5 colors"
+    colors={urbanColors.getCategoricalColors(5)}
   />
 </ColorPalette>
 
 Usage:
+
 ```js
 urbanColors.getCategoricalColors(5);
 ```
 
 Color values:
+
 ```js
-[ "#1696D2", "#FDBF11", "#000000", "#EC00BB", "#D2D2D2" ]
+["#1696D2", "#FDBF11", "#000000", "#EC00BB", "#D2D2D2"];
 ```
 
 ## Diverging colors
@@ -277,19 +268,21 @@ Color values:
 <ColorPalette>
   <ColorItem
     title="Diverging colors"
-     subtitle="Useful for maps with diverging data"
-     colors={urbanColors.getDivergingColors()}
+    subtitle="Useful for maps with diverging data"
+    colors={urbanColors.getDivergingColors()}
   />
 </ColorPalette>
 
 Usage:
+
 ```js
 urbanColors.getDivergingColors();
 ```
 
 Color values:
+
 ```js
-[ "#CA5800", "#FDBF11", "#FDD870", "#FFF2CF", "#CFE8F3", "#73BFE2", "#1696D2", "#0A4C6A" ]
+["#CA5800", "#FDBF11", "#FDD870", "#FFF2CF", "#CFE8F3", "#73BFE2", "#1696D2", "#0A4C6A"];
 ```
 
 ## Blues for maps
@@ -297,19 +290,17 @@ Color values:
 The style guide specifies a specific set of colors for usage in choropleth maps.
 
 <ColorPalette>
-  <ColorItem
-    title="Blue colors for maps"
-     subtitle=""
-     colors={urbanColors.getMapBlues()}
-  />
+  <ColorItem title="Blue colors for maps" subtitle="" colors={urbanColors.getMapBlues()} />
 </ColorPalette>
 
 Usage:
+
 ```js
 urbanColors.getMapBlues();
 ```
 
 Color values:
+
 ```js
-[ "#CFE8F3", "#73BFE2", "#1696D2", "#0A4C6A", "#000000", ]
+["#CFE8F3", "#73BFE2", "#1696D2", "#0A4C6A", "#000000"];
 ```

--- a/src/lib/utils/helperFunctions.docs.mdx
+++ b/src/lib/utils/helperFunctions.docs.mdx
@@ -5,6 +5,8 @@ import { kebabCase, dollarFormat } from "./";
 
 # Helper Functions
 
+[![github](https://badgen.net/badge/icon/GitHub?icon=github&label)](https://github.com/UrbanInstitute/dataviz-components/tree/main/src/lib/utils)
+
 The helper functions are provided to save time during development. They can be for string/number formatting and more.
 
 To use these, utilities, import the module like so:


### PR DESCRIPTION
### What's in this pull request

- [x] Documentation update

### Description

Adds GitHub link for component sourcecode [plugin link here](https://storybook.js.org/addons/@etchteam/storybook-addon-github-link). ~~Opening a PR on init commit to start the conversation~~. Recommendation to link directly to the component `.svelte` file.

**This will be a manual add for each story** since the "auto" feature in this plugin uses the storybook page route to build the GH link. I think this would be worth it!

Edit: Completed. Implemented with addon for `.stories` files and manual github icon/link add to `.docs.mdx`.

### Before submitting, please check that you've

- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section