### PR TITLE
Icon gallery reorganization

### DIFF
--- a/.storybook/manager.head.html
+++ b/.storybook/manager.head.html
@@ -1,0 +1,10 @@
+<style>
+  .docblock-icongallery div {
+    min-width: 150px;
+  }
+
+  .docblock-icongallery div div {
+    height: 60px;
+    width: 60px;
+  }
+</style>

--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -7,4 +7,8 @@
     height: 60px;
     width: 60px;
   }
+
+  .docblock-icongallery .sb-story {
+    height: 40px;
+  }
 </style>

--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,9 +1,9 @@
 <style>
-  .docblock-icongallery div {
+  .docblock-icongallery > div {
     min-width: 150px;
   }
 
-  .docblock-icongallery div div {
+  .docblock-icongallery > div > div:first-child {
     height: 60px;
     width: 60px;
   }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
       "types": "./dist/maps/index.d.ts",
       "svelte": "./dist/maps/index.js"
     },
+    "./icons": {
+      "types": "./dist/icons/index.d.ts",
+      "svelte": "./dist/icons/index.js"
+    },
     "./style": "./dist/style/main.css",
     "./style/theme": "./dist/style/theme.css"
   },

--- a/src/lib/Icons/IconClose.stories.svelte
+++ b/src/lib/Icons/IconClose.stories.svelte
@@ -1,50 +1,24 @@
 <script context="module">
-    import IconClose from "./IconClose.svelte";
-  
-    export const meta = {
-      title: "Icons/Other Icons/IconClose",
-      component: IconClose,
-      tags: ["!dev","!autodocs"],
-      argTypes: {
-        size: {
-          default: 40
-        },
-        fill: {
-          control: {
-            type: "color",
-            presetColors: ["#000", "#1696D2", "#fbdf11"]
-          }
-        }
-      },
-      parameters: {
-        backgrounds: {
-          default: "light",
-          values: [
-            { name: "light", value: "#ffffff" },
-            { name: "dark", value: "#0A4C6A" }
-          ]
-        },
-        docs: {
-          description: {
-            component:
-              "Any of these icons can be pulled in as standalone components. They are intended as decorations, and do not include `onClick` parameters. "
-          }
-        },
-        githubLink: {
-          url: "/Icons/IconClose.svelte"
-        }
+  import IconClose from "./IconClose.svelte";
+
+  export const meta = {
+    title: "Icons/Icons/IconClose",
+    component: IconClose,
+    tags: ["!dev", "!autodocs"],
+    parameters: {
+      githubLink: {
+        url: "/Icons/IconClose.svelte"
       }
-    };
-  </script>
-  
-  <script>
-    import { Story, Template } from "@storybook/addon-svelte-csf";
-  </script>
-  
-  <Template let:args>
-    <IconClose {...args} />
-  </Template>
-  
-  <Story name="ClosePreview">
-    <IconClose size={25}/>
-  </Story>
+    }
+  };
+</script>
+
+<script>
+  import { Story, Template } from "@storybook/addon-svelte-csf";
+</script>
+
+<Template let:args>
+  <IconClose {...args} />
+</Template>
+
+<Story name="Default" />

--- a/src/lib/Icons/IconMinus.stories.svelte
+++ b/src/lib/Icons/IconMinus.stories.svelte
@@ -1,50 +1,48 @@
 <script context="module">
-    import IconMinus from "./IconMinus.svelte";
-  
-    export const meta = {
-      title: "Icons/Other Icons/IconMinus",
-      component: IconMinus,
-      tags: ["!dev","!autodocs"],
-      argTypes: {
-        size: {
-          default: 40
-        },
-        fill: {
-          control: {
-            type: "color",
-            presetColors: ["#000", "#1696D2", "#fbdf11"]
-          }
-        }
+  import IconMinus from "./IconMinus.svelte";
+
+  export const meta = {
+    title: "Icons/Icons/IconMinus",
+    component: IconMinus,
+    tags: ["!dev", "!autodocs"],
+    argTypes: {
+      size: {
+        default: 40
       },
-      parameters: {
-        backgrounds: {
-          default: "light",
-          values: [
-            { name: "light", value: "#ffffff" },
-            { name: "dark", value: "#0A4C6A" }
-          ]
-        },
-        docs: {
-          description: {
-            component:
-              "Any of these icons can be pulled in as standalone components. They are intended as decorations, and do not include `onClick` parameters. "
-          }
-        },
-        githubLink: {
-          url: "/Icons/IconMinus.svelte"
+      fill: {
+        control: {
+          type: "color",
+          presetColors: ["#000", "#1696D2", "#fbdf11"]
         }
       }
-    };
-  </script>
-  
-  <script>
-    import { Story, Template } from "@storybook/addon-svelte-csf";
-  </script>
-  
-  <Template let:args>
-    <IconMinus {...args} />
-  </Template>
-  
-  <Story name="MinusPreview">
-    <IconMinus size={25}/>
-  </Story>
+    },
+    parameters: {
+      backgrounds: {
+        default: "light",
+        values: [
+          { name: "light", value: "#ffffff" },
+          { name: "dark", value: "#0A4C6A" }
+        ]
+      },
+      docs: {
+        description: {
+          component:
+            "Any of these icons can be pulled in as standalone components. They are intended as decorations, and do not include `onClick` parameters. "
+        }
+      },
+      githubLink: {
+        url: "/Icons/IconMinus.svelte"
+      }
+    }
+  };
+</script>
+
+<script>
+  import { Story, Template } from "@storybook/addon-svelte-csf";
+</script>
+
+<Template let:args>
+  <IconMinus {...args} />
+</Template>
+
+<Story name="Default" />

--- a/src/lib/Icons/IconMinus.stories.svelte
+++ b/src/lib/Icons/IconMinus.stories.svelte
@@ -5,31 +5,7 @@
     title: "Icons/Icons/IconMinus",
     component: IconMinus,
     tags: ["!dev", "!autodocs"],
-    argTypes: {
-      size: {
-        default: 40
-      },
-      fill: {
-        control: {
-          type: "color",
-          presetColors: ["#000", "#1696D2", "#fbdf11"]
-        }
-      }
-    },
     parameters: {
-      backgrounds: {
-        default: "light",
-        values: [
-          { name: "light", value: "#ffffff" },
-          { name: "dark", value: "#0A4C6A" }
-        ]
-      },
-      docs: {
-        description: {
-          component:
-            "Any of these icons can be pulled in as standalone components. They are intended as decorations, and do not include `onClick` parameters. "
-        }
-      },
       githubLink: {
         url: "/Icons/IconMinus.svelte"
       }

--- a/src/lib/Icons/IconPlus.stories.svelte
+++ b/src/lib/Icons/IconPlus.stories.svelte
@@ -1,58 +1,57 @@
 <script context="module">
-    import IconPlus from "./IconPlus.svelte";
-  
-    export const meta = {
-      title: "Icons/Icon",
-      component: IconPlus,
-      //tags: ["autodocs"],
-      argTypes: {
-        size: {
-          default: 40
-        },
-        fill: {
-          control: {
-            type: "color",
-            presetColors: ["#000", "#1696D2", "#fbdf11"]
-          }
-        }
+  import IconPlus from "./IconPlus.svelte";
+
+  export const meta = {
+    title: "Icons/Icons/IconPlus",
+    component: IconPlus,
+    //tags: ["autodocs"],
+    argTypes: {
+      size: {
+        default: 40
       },
-      parameters: {
-        backgrounds: {
-          default: "light",
-          values: [
-            { name: "light", value: "#ffffff" },
-            { name: "dark", value: "#0A4C6A" }
-          ]
-        },
-        docs: {
-          description: {
-            component:
-              "Any of these icons can be pulled in as standalone components. They are intended as decorations, and do not include `onClick` parameters. "
-          }
-        },
-        githubLink: {
-          url: "/Icons/IconPlus.svelte"
+      fill: {
+        control: {
+          type: "color",
+          presetColors: ["#000", "#1696D2", "#fbdf11"]
         }
       }
-    };
-  </script>
-  
-  <script>
-    import { Story, Template } from "@storybook/addon-svelte-csf";
-    import urbanColors from "$lib/utils/urbanColors.js";
-  </script>
-  
-  <Template let:args>
-    <IconPlus {...args} />
-  </Template>
-  
-  <Story name="Default" />
-  
-  <Story name="WithColor">
-    <IconPlus fill={urbanColors.blue} />
-  </Story>
-  
-  <Story name="ChangingSize">
-    <IconPlus size={65} />
-  </Story>
-  
+    },
+    parameters: {
+      backgrounds: {
+        default: "light",
+        values: [
+          { name: "light", value: "#ffffff" },
+          { name: "dark", value: "#0A4C6A" }
+        ]
+      },
+      docs: {
+        description: {
+          component:
+            "Any of these icons can be pulled in as standalone components. They are intended as decorations, and do not include `onClick` parameters. "
+        }
+      },
+      githubLink: {
+        url: "/Icons/IconPlus.svelte"
+      }
+    }
+  };
+</script>
+
+<script>
+  import { Story, Template } from "@storybook/addon-svelte-csf";
+  import urbanColors from "$lib/utils/urbanColors.js";
+</script>
+
+<Template let:args>
+  <IconPlus {...args} />
+</Template>
+
+<Story name="Default" />
+
+<Story name="WithColor">
+  <IconPlus fill={urbanColors.blue} />
+</Story>
+
+<Story name="ChangingSize">
+  <IconPlus size={65} />
+</Story>

--- a/src/lib/Icons/IconSearch.stories.svelte
+++ b/src/lib/Icons/IconSearch.stories.svelte
@@ -5,31 +5,7 @@
     title: "Icons/Icons/IconSearch",
     component: IconSearch,
     tags: ["!dev", "!autodocs"],
-    argTypes: {
-      size: {
-        default: 40
-      },
-      fill: {
-        control: {
-          type: "color",
-          presetColors: ["#000", "#1696D2", "#fbdf11"]
-        }
-      }
-    },
     parameters: {
-      backgrounds: {
-        default: "light",
-        values: [
-          { name: "light", value: "#ffffff" },
-          { name: "dark", value: "#0A4C6A" }
-        ]
-      },
-      docs: {
-        description: {
-          component:
-            "Any of these icons can be pulled in as standalone components. They are intended as decorations, and do not include `onClick` parameters. "
-        }
-      },
       githubLink: {
         url: "/Icons/IconSearch.svelte"
       }

--- a/src/lib/Icons/IconSearch.stories.svelte
+++ b/src/lib/Icons/IconSearch.stories.svelte
@@ -1,50 +1,48 @@
 <script context="module">
-    import IconSearch from "./IconSearch.svelte";
-  
-    export const meta = {
-      title: "Icons/Other Icons/IconSearch",
-      component: IconSearch,
-      tags: ["!dev","!autodocs"],
-      argTypes: {
-        size: {
-          default: 40
-        },
-        fill: {
-          control: {
-            type: "color",
-            presetColors: ["#000", "#1696D2", "#fbdf11"]
-          }
-        }
+  import IconSearch from "./IconSearch.svelte";
+
+  export const meta = {
+    title: "Icons/Icons/IconSearch",
+    component: IconSearch,
+    tags: ["!dev", "!autodocs"],
+    argTypes: {
+      size: {
+        default: 40
       },
-      parameters: {
-        backgrounds: {
-          default: "light",
-          values: [
-            { name: "light", value: "#ffffff" },
-            { name: "dark", value: "#0A4C6A" }
-          ]
-        },
-        docs: {
-          description: {
-            component:
-              "Any of these icons can be pulled in as standalone components. They are intended as decorations, and do not include `onClick` parameters. "
-          }
-        },
-        githubLink: {
-          url: "/Icons/IconSearch.svelte"
+      fill: {
+        control: {
+          type: "color",
+          presetColors: ["#000", "#1696D2", "#fbdf11"]
         }
       }
-    };
-  </script>
-  
-  <script>
-    import { Story, Template } from "@storybook/addon-svelte-csf";
-  </script>
-  
-  <Template let:args>
-    <IconSearch {...args} />
-  </Template>
-  
-  <Story name="SearchPreview">
-    <IconSearch size={25}/>
-  </Story>
+    },
+    parameters: {
+      backgrounds: {
+        default: "light",
+        values: [
+          { name: "light", value: "#ffffff" },
+          { name: "dark", value: "#0A4C6A" }
+        ]
+      },
+      docs: {
+        description: {
+          component:
+            "Any of these icons can be pulled in as standalone components. They are intended as decorations, and do not include `onClick` parameters. "
+        }
+      },
+      githubLink: {
+        url: "/Icons/IconSearch.svelte"
+      }
+    }
+  };
+</script>
+
+<script>
+  import { Story, Template } from "@storybook/addon-svelte-csf";
+</script>
+
+<Template let:args>
+  <IconSearch {...args} />
+</Template>
+
+<Story name="Default" />

--- a/src/lib/Icons/Icons.docs.mdx
+++ b/src/lib/Icons/Icons.docs.mdx
@@ -4,37 +4,32 @@ import * as CloseStory from "./IconClose.stories.svelte";
 import * as SearchStory from "./IconSearch.stories.svelte";
 import { Meta, Title, Canvas, Story, Controls, IconGallery, IconItem } from "@storybook/blocks";
 
-<Meta title="Icons/Icons" of={PlusStories} />
+<Meta title="Icons" />
 
 # Icons
 
 Any of these icons can be pulled in as standalone components. They are intended as decorations, and do not include `onClick` parameters.
 
+```js
+import { IconPlus } from "@urbaninstitute/dataviz-components/icons";
+```
+
 ## Options
+
 These are the current possible icon components included with this library.
 
 <IconGallery>
   <IconItem name="IconPlus">
-    <svg
-    width={25}
-    height={25}
-    viewBox="0 0 48 48"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    role="img"
-    aria-label="Plus icon"
-  >
-  <path d="M0 27V21H48V27H0Z M28 48H22L22 2.62268e-07L28 0L28 48Z" fill="#000" />
-</svg>
+    <Story of={PlusStories.Default} />
   </IconItem>
   <IconItem name="IconMinus">
-    <Story of={MinusStory.MinusPreview}/>
+    <Story of={MinusStory.Default} />
   </IconItem>
   <IconItem name="IconClose">
-    <Story of={CloseStory.ClosePreview}/>
+    <Story of={CloseStory.Default} />
   </IconItem>
   <IconItem name="IconSearch">
-    <Story of={SearchStory.SearchPreview}/>
+    <Story of={SearchStory.Default} />
   </IconItem>
 </IconGallery>
 
@@ -42,7 +37,7 @@ These are the current possible icon components included with this library.
 
 <Canvas of={PlusStories.Default} />
 
-<Controls />
+<Controls of={PlusStories.Default} />
 
 ## With color change
 


### PR DESCRIPTION
Let me know what you think about some of these proposed changes, idea is to build on what you have but simplify the story setup a little bit since we'll have 30+ to create! I was also able to modify the css of the icon gallery so the items are big enough to capture the default size of our icons at 40w/h!

Note: the `package.json` edit for the icons subfolder when importing!