### PR TITLE
Fix threshold scale ticks and add NA option to ColorScale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Feature: Add Layercake AxisX and AxisY components and docs
 - Feature: Add Icon components [close, plus, minus, search]
 - Fix: ColorLegend compontent displays threshold scale ticks correctly
+- Feature: ColorLegend supports an N/A item
 
 ## v0.10.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Feature: CLI command to generate new component boilerplate (`npm run create-component`)
 - Feature: Add Layercake AxisX and AxisY components and docs
 - Feature: Add Icon components [close, plus, minus, search]
+- Fix: ColorLegend compontent displays threshold scale ticks correctly
 
 ## v0.10.2
 

--- a/src/lib/maps/ColorLegend/ColorLegend.svelte
+++ b/src/lib/maps/ColorLegend/ColorLegend.svelte
@@ -136,13 +136,31 @@
    */
   export let swatchSpacing = undefined;
 
+  /**
+   * Optional color to indicate for NA values
+   * @type { string } [naFill = undefined]
+   */
+  export let naFill = undefined;
+
+  /**
+   * Optional string label for NA values
+   * @type { string } [naLabel = "NA"]
+   */
+  export let naLabel = "NA";
+
+  export let naSize = 16;
+
+  export let naSpacing = 16;
+
   // will hold width of DOM element
   let width;
 
   $: domain = scale.domain();
   $: range = scale.range();
 
-  $: legendWidth = width - margin.left - margin.right;
+  $: legendWidth = naFill
+    ? width - margin.left - margin.right - naSize - naSpacing
+    : width - margin.left - margin.right;
 
   /**
    * @type { scaleType }
@@ -171,11 +189,7 @@
 
   function getTickFormatFn(tickFormat, thresholds) {
     // respect any user provided options first
-    if (typeof tickFormat === "string") {
-      return format(tickFormat);
-    } else if (tickFormat) {
-      return tickFormat;
-    } else if (thresholds) {
+    if (thresholds) {
       // if we have a threshold scale without any use-provided formatting, generate threshold ticks
       const thresholdFormat =
         tickFormat === undefined
@@ -185,6 +199,12 @@
             : tickFormat;
 
       return (i) => thresholdFormat(thresholds[i], i);
+    }
+    if (typeof tickFormat === "string") {
+      return format(tickFormat);
+    }
+    if (tickFormat && !thresholds) {
+      return tickFormat;
     }
     return (d) => d;
   }
@@ -251,7 +271,7 @@
     if (tickTextAnchor !== "auto") {
       return tickTextAnchor;
     }
-    if (scaleType === "ordinal") {
+    if (scaleType === "ordinal" || thresholds) {
       return "middle";
     }
     if (val === domain[0]) {
@@ -264,7 +284,12 @@
   }
 </script>
 
-<div class="legend-wrapper" bind:clientWidth={width} style:max-width="{maxWidth}px" style:padding-bottom="10px">
+<div
+  class="legend-wrapper"
+  bind:clientWidth={width}
+  style:max-width="{maxWidth}px"
+  style:padding-bottom="10px"
+>
   {#if title}
     <p class="legend-title">{title}</p>
   {/if}
@@ -316,6 +341,15 @@
               ></rect>
             {/each}
           {/if}
+          {#if naFill}
+            <rect
+              x={legendWidth + margin.left + naSpacing}
+              y="0"
+              width={naSize}
+              {height}
+              fill={naFill}
+            />
+          {/if}
           {#if scaleType && width && xScale}
             <g class="legend-ticks">
               {#each legendTicks as tick}
@@ -341,6 +375,16 @@
                   text-anchor={getTextAnchor(tick, domain)}>{tickFormatFn(tick)}</text
                 >
               {/each}
+              {#if naFill}
+                <text
+                  fill="black"
+                  alignment-baseline={tickPosition === "top" ? "hanging" : "baseline"}
+                  y={tickPosition === "top" ? 0 : height + tickMargin + tickSize}
+                  x={legendWidth + margin.left + naSpacing + naSize / 2}
+                  font-size="{tickSize}px"
+                  text-anchor={"middle"}>{naLabel}</text
+                >
+              {/if}
             </g>
           {/if}
         </g>

--- a/src/lib/maps/ColorLegend/ColorLegend.svelte
+++ b/src/lib/maps/ColorLegend/ColorLegend.svelte
@@ -194,7 +194,6 @@
 
   $: tickFormatFn = getTickFormatFn(tickFormat, thresholds);
   $: legendTicks = getTicks(scaleType, xScale, thresholds);
-  $: console.log(legendTicks);
 
   function getTickFormatFn(tickFormat, thresholds) {
     // respect any user provided options first

--- a/src/lib/maps/ColorLegend/ColorLegend.svelte
+++ b/src/lib/maps/ColorLegend/ColorLegend.svelte
@@ -67,7 +67,7 @@
 
   /**
    * Optional tick formatting string or function
-   * @type { string | (Object) => string } [tickFormat = undefined]
+   * @type { string | (a: Object) => string } [tickFormat = undefined]
    */
   export let tickFormat = undefined;
 
@@ -148,8 +148,16 @@
    */
   export let naLabel = "NA";
 
+  /**
+   * Optional size in pixels for naLabel
+   * @type { string } [naLabel = "NA"]
+   */
   export let naSize = 16;
 
+  /**
+   * Optional amount of spacing in pixels for NA swatch and label
+   * @type { string } [naLabel = "NA"]
+   */
   export let naSpacing = 16;
 
   // will hold width of DOM element
@@ -186,6 +194,7 @@
 
   $: tickFormatFn = getTickFormatFn(tickFormat, thresholds);
   $: legendTicks = getTicks(scaleType, xScale, thresholds);
+  $: console.log(legendTicks);
 
   function getTickFormatFn(tickFormat, thresholds) {
     // respect any user provided options first


### PR DESCRIPTION
### What's in this pull request

- [x] Bug fix


### Description

Fixes a bug where ColorLegend displayed threshold scale tick marks incorrectly.
Adds option for an N/A item in legend.

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
- [x] If this pull request includes a new component or feature, has it been exported from one of the library's entry points?
- [x] Does the component dispatch relevant interaction events? (ie: on:click, on:change, etc.)
- [x] Does the component directory include description and usage information in `.stories.svelte`?
