### PR TITLE
Fix tooltip style calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # @UrbanInstitute/dataviz-components Changelog
 
 ## Next
+- Fix: Tooltip checks if ancestor is an instance of Element before calling getComputedStyle
 
 ## v0.12.2
 - Fix: Color scale resets ticks when switching from threshold scale to continuous scale

--- a/src/lib/Tooltip/Tooltip.svelte
+++ b/src/lib/Tooltip/Tooltip.svelte
@@ -155,7 +155,7 @@
     if (!el) return;
     // traverse the tree upwards to see if there are any absolutely, fixed or relatively positioned ancestors
     let ancestor = el.parentNode;
-    while (ancestor && ancestor !== document.documentElement) {
+    while (ancestor && ancestor !== document.documentElement && ancestor instanceof Element) {
       const position = window.getComputedStyle(ancestor).position;
       if (position === "relative" || position === "absolute" || position === "fixed") {
         return ancestor;


### PR DESCRIPTION
### What's in this pull request

- [x] Bug fix
- [ ] New component/feature
- [ ] Component update
- [ ] Documentation update
- [ ] Other

### Description

Tooltip would throw error when inside of web component. This fix checks if ancestors are instances of Element before calling getComputedStyle on them. This avoids the error.

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [ ] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
- [x] If this pull request includes a new component or feature, has it been exported from one of the library's entry points?
- [x] Does the component dispatch relevant interaction events? (ie: on:click, on:change, etc.)
- [x] Does the component directory include description and usage information in `.stories.svelte`?
