### PR TITLE
Fix: tooltip position inside shadow root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # @UrbanInstitute/dataviz-components Changelog
 
 ## Next
+- Fix: Tooltip positioning works as expected when inside a ShadowRoot of a custom element
 
 ## v0.12.3
 - Fix: Tooltip checks if ancestor is an instance of Element before calling getComputedStyle

--- a/src/lib/Tooltip/Tooltip.svelte
+++ b/src/lib/Tooltip/Tooltip.svelte
@@ -155,12 +155,27 @@
     if (!el) return;
     // traverse the tree upwards to see if there are any absolutely, fixed or relatively positioned ancestors
     let ancestor = el.parentNode;
-    while (ancestor && ancestor !== document.documentElement && ancestor instanceof Element) {
-      const position = window.getComputedStyle(ancestor).position;
-      if (position === "relative" || position === "absolute" || position === "fixed") {
-        return ancestor;
+    // loop through all ancestors until we reach the document element
+    while (ancestor && ancestor !== document.documentElement) {
+      // check if ancestor is a shadow root with a host element
+      if (ancestor instanceof ShadowRoot) {
+        // if it is, set ancestor to the host element instead
+        ancestor = ancestor.host;
       }
-      ancestor = ancestor.parentNode;
+      // make sure ancestor is instance of element
+      if (ancestor instanceof Element) {
+        // if it is, check if it is relative, absolute or fixed position
+        const position = window.getComputedStyle(ancestor).position;
+        // return it if so
+        if (position === "relative" || position === "absolute" || position === "fixed") {
+          return ancestor;
+        }
+        // check next ancestor
+        ancestor = ancestor.parentNode;
+      } else {
+        // if ancestor is not an element, break the loop
+        break;
+      }
     }
     return null;
   }


### PR DESCRIPTION

### What's in this pull request

- [x] Bug fix

### Description

Tooltip now positions correctly when it is inside the shadowroot of a custom element and that custom element is inside a fixed, absolute or relatively positioned ancestor.

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
- [x] If this pull request includes a new component or feature, has it been exported from one of the library's entry points?
- [x] Does the component dispatch relevant interaction events? (ie: on:click, on:change, etc.)
- [x] Does the component directory include description and usage information in `.stories.svelte`?
