### PR TITLE
Patch css color green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # @UrbanInstitute/dataviz-components Changelog
 
 ## Next
+- Fix: CSS Theme variable --color-green was #55b748, which is a kind of yellow. Changed to match style guide.
 
 ## v0.12.4
 - Fix: Tooltip positioning works as expected when inside a ShadowRoot of a custom element

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # @UrbanInstitute/dataviz-components Changelog
 
 ## Next
-- Fix: CSS Theme variable --color-green was #55b748, which is a kind of yellow. Changed to match style guide.
+- Fix: CSS Theme variable --color-green was #ffb748, which is a kind of yellow. Changed to match style guide.
 
 ## v0.12.4
 - Fix: Tooltip positioning works as expected when inside a ShadowRoot of a custom element

--- a/src/lib/Theme/Theme.svelte
+++ b/src/lib/Theme/Theme.svelte
@@ -70,7 +70,7 @@
     --color-green-shade-darkest: #1a2e19;
     --color-green-shade-darker: #2c5c2d;
     --color-green-shade-dark: #408941;
-    --color-green: #ffb748;
+    --color-green: #55b748;
     --color-green-shade-medium: #78c26d;
     --color-green-shade-light: #98cf90;
     --color-green-shade-lighter: #bcdeb4;


### PR DESCRIPTION
### What's in this pull request

- [x] Bug fix

### Description

The CSS variable --color-green was a kind of yellow. Updated to match style guide.

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
