### PR TITLE
Patch headline eyebrow link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # @UrbanInstitute/dataviz-components Changelog
 
 ## Next
+- Patch: Headline eyebrows in Drupal include a link to the Story or Data tool homepage; tweaked Headline component to do the same.
 - Fix: CSS Theme variable --color-green was #ffb748, which is a kind of yellow. Changed to match style guide.
 
 ## v0.12.4

--- a/src/lib/Headline/Headline.svelte
+++ b/src/lib/Headline/Headline.svelte
@@ -15,7 +15,7 @@
   export let description = null;
 
   /**
-   * Optional eyebrow to be displayed above the headline; determines eyebrow link.
+   * Optional eyebrow to be displayed above the headline. Determines eyebrow link.
    * @type {string | null}
    */
   export let eyebrow = null;

--- a/src/lib/Headline/Headline.svelte
+++ b/src/lib/Headline/Headline.svelte
@@ -55,6 +55,8 @@
   <div class="headline-wrap {variant}">
     {#if $$slots.eyebrow}
       <!--
+      Optional slot for custom content in the eyebrow slot.
+       -->
       <slot name="eyebrow" />
     {:else if eyebrow}
       {#if eyebrow.toLowerCase() == "data tool"}
@@ -71,18 +73,24 @@
     {/if}
     {#if $$slots.headline}
       <!--
+      Optional slot for custom content in the headline slot.
+       -->
       <slot name="headline" />
     {:else}
       <h1 class="headline-page-headline">{headline}</h1>
     {/if}
     {#if $$slots.description}
       <!--
+      Optional slot for custom content in the description slot.
+       -->
       <slot name="description" />
     {:else if description}
       <p class="headline-description">{description}</p>
     {/if}
     {#if $$slots.date}
       <!--
+      Optional slot for custom content in the date slot.
+       -->
       <slot name="date" />
     {:else if date}
       <p class="headline-date">
@@ -93,6 +101,8 @@
       </p>
     {/if}
     <!--
+    Optional slot for extra content to include below the date and above the share buttons.
+     -->
     <slot name="extra" />
     <hr class="headline-rule" />
   </div>

--- a/src/lib/Headline/Headline.svelte
+++ b/src/lib/Headline/Headline.svelte
@@ -15,7 +15,7 @@
   export let description = null;
 
   /**
-   * Optional eyebrow to be displayed above the headline.
+   * Optional eyebrow to be displayed above the headline; determines eyebrow link.
    * @type {string | null}
    */
   export let eyebrow = null;
@@ -55,32 +55,34 @@
   <div class="headline-wrap {variant}">
     {#if $$slots.eyebrow}
       <!--
-        Optional slot for custom content in the eyebrow slot.
-         -->
       <slot name="eyebrow" />
     {:else if eyebrow}
-      <p class="headline-eyebrow">{eyebrow}</p>
+      {#if eyebrow.toLowerCase() == "data tool"}
+        <a href="https://www.urban.org/data-tools" target="_blank"
+          ><p class="headline-eyebrow">{eyebrow}</p></a
+        >
+      {:else if eyebrow.toLowerCase() == "story"}
+        <a href="https://www.urban.org/stories" target="_blank"
+          ><p class="headline-eyebrow">{eyebrow}</p></a
+        >
+      {:else}
+        <p class="headline-eyebrow">{eyebrow}</p>
+      {/if}
     {/if}
     {#if $$slots.headline}
       <!--
-        Optional slot for custom content in the headline slot.
-         -->
       <slot name="headline" />
     {:else}
       <h1 class="headline-page-headline">{headline}</h1>
     {/if}
     {#if $$slots.description}
       <!--
-        Optional slot for custom content in the description slot.
-         -->
       <slot name="description" />
     {:else if description}
       <p class="headline-description">{description}</p>
     {/if}
     {#if $$slots.date}
       <!--
-        Optional slot for custom content in the date slot.
-         -->
       <slot name="date" />
     {:else if date}
       <p class="headline-date">
@@ -91,8 +93,6 @@
       </p>
     {/if}
     <!--
-      Optional slot for extra content to include below the date and above the share buttons.
-       -->
     <slot name="extra" />
     <hr class="headline-rule" />
   </div>
@@ -147,5 +147,9 @@
   .headline-wrap p.headline-eyebrow {
     font-size: var(--font-size-small);
     text-transform: uppercase;
+  }
+  .headline-wrap p.headline-eyebrow:hover {
+    text-decoration: underline;
+    cursor: pointer;
   }
 </style>


### PR DESCRIPTION
### What's in this pull request

- [x] Component update

### Description

In non-apps project Stories or Data tools (by the Urban dot org categorization), Headline eyebrows link out to either [https://www.urban.org/data-tools](https://www.urban.org/data-tools) or [https://www.urban.org/stories](https://www.urban.org/stories). 

Our headline component now detects when the eyebrow is Data tool or Story (checking against lowercased version of the string) and adds the proper link out, following the style in Drupal (underline the link on hover). If the eyebrow is not Data tool or Story, it stays a p tag. 

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
- [x] Does the component directory include description and usage information in `.stories.svelte`?
