### PR TITLE
add export for IconRefresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # @UrbanInstitute/dataviz-components Changelog
 
 ## Next
+- Patch: IconRefresh didn't have an export; added it.
 
 ## v0.12.6
 - Patch: DatawrapperSwitching story to wrap the bottom block in `if` instead of `key`. 

--- a/src/lib/Icons/index.js
+++ b/src/lib/Icons/index.js
@@ -2,3 +2,4 @@ export { default as IconClose } from "./IconClose.svelte";
 export { default as IconPlus } from "./IconPlus.svelte";
 export { default as IconMinus } from "./IconMinus.svelte";
 export { default as IconSearch } from "./IconSearch.svelte";
+export { default as IconRefresh } from "./IconRefresh.svelte";


### PR DESCRIPTION
IconRefresh was in our storybook but was not exported and thus was unusable

### What's in this pull request

- [x] Bug fix

### Description

adds IconRefresh to Icons directory export file

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
