### PR TITLE
Patch analytics inspect pageview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 - Patch: IconRefresh didn't have an export; added it.
+- Patch: Analytics component sends dev-only start-up console log about state of sendPageview.
 
 ## v0.12.6
 - Patch: DatawrapperSwitching story to wrap the bottom block in `if` instead of `key`. 

--- a/src/lib/Analytics/Analytics.svelte
+++ b/src/lib/Analytics/Analytics.svelte
@@ -46,6 +46,7 @@
     window.ui_dataviz_config = window.ui_dataviz_config || {};
     window.ui_dataviz_config.analytics_title = title;
     window.ui_dataviz_config.analytics_mode = mode;
+    $inspect(sendPageview ? "You are sending page views to GA, as for a full page app." : "You are not sending page views to GA, as for an iframe embed.");
   });
 </script>
 

--- a/src/lib/Analytics/Analytics.svelte
+++ b/src/lib/Analytics/Analytics.svelte
@@ -46,7 +46,13 @@
     window.ui_dataviz_config = window.ui_dataviz_config || {};
     window.ui_dataviz_config.analytics_title = title;
     window.ui_dataviz_config.analytics_mode = mode;
-    $inspect(sendPageview ? "You are sending page views to GA, as for a full page app." : "You are not sending page views to GA, as for an iframe embed.");
+    if (mode == "development"){
+      console.log(
+        sendPageview
+          ? "You are sending page views to GA, as for a full page app."
+          : "You are not sending page views to GA, as for an iframe embed."
+      );
+    }
   });
 </script>
 


### PR DESCRIPTION
### What's in this pull request

- [x] Component update

### Description

To ensure page views are a decision contemplated in all cases, I added an inspect log in the analytics component which will only appear on dev. It will remind developers to consider whether to turn off page views for quickturn embed projects while not imposing heavily on longterm feature work.

#### default: `sendPageview` set to `true`
![Screenshot 2025-02-11 at 11 22 46 AM](https://github.com/user-attachments/assets/e8feb2c7-3e5d-4a2a-9cba-5b3c1c559c95)

#### `sendPageview` set to `false`
![Screenshot 2025-02-11 at 11 23 07 AM](https://github.com/user-attachments/assets/f8100e1a-496d-4aef-9dc7-5656c72ce20e)

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
