### PR TITLE
Feat: add robotsNoIndex to meta component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # @UrbanInstitute/dataviz-components Changelog
 
 ## Next
+- Feature: add `robotsNoIndex` option to Meta component
 
 ## v0.13.0
 - Fix: Allow HTML content for title and description field in ChartBlock component

--- a/src/lib/Meta/Meta.stories.svelte
+++ b/src/lib/Meta/Meta.stories.svelte
@@ -29,7 +29,7 @@
 </script>
 
 <Template let:args>
-  <Meta />
+  <Meta {...args} />
 </Template>
 
 <Story
@@ -42,5 +42,19 @@
     authors: ["Author Name", "Author Name"],
     keywords: ["keyword1", "keyword2"],
     socialImage: ""
+  }}>Nothing to see here</Story
+>
+
+<Story
+  name="No Index"
+  args={{
+    title: "",
+    description: "",
+    url: "",
+    siteName: "Urban Institute",
+    authors: ["Author Name", "Author Name"],
+    keywords: ["keyword1", "keyword2"],
+    socialImage: "",
+    robotsNoIndex: true
   }}>Nothing to see here</Story
 >

--- a/src/lib/Meta/Meta.svelte
+++ b/src/lib/Meta/Meta.svelte
@@ -56,6 +56,12 @@
    */
   export let articleSection = "Data Tool";
 
+  /**
+   * Should the page be hidden from search engines?
+   * @type {boolean}
+   */
+  export let robotsNoIndex = false;
+
   $: schemaMeta = {
     "@context": "http://schema.org",
     "@type": "NewsArticle",
@@ -95,6 +101,9 @@
   <meta name="twitter:image" content={socialImage} />
 
   <meta name="robots" content="max-image-preview:large" />
+  {#if robotsNoIndex}
+    <meta name="robots" content="noindex" />
+  {/if}
 
   <link rel="canonical" href={url} />
 


### PR DESCRIPTION


### What's in this pull request

- [x] New component/feature


### Description

- Adds option to hide a page from search results. This is particularly useful for content designed to be embedded in another page.

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
- [x] If this pull request includes a new component or feature, has it been exported from one of the library's entry points?
- [x] Does the component dispatch relevant interaction events? (ie: on:click, on:change, etc.)
- [x] Does the component directory include description and usage information in `.stories.svelte`?
