### PR TITLE
Feat map tooltip size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+## v1.0.4
+- Feat: SVGMap has tooltipSize prop to determine large or small tooltips
+
 ## v1.0.3
 - Fix: Fixes issue with getFeatureHighlight function in SVGMap that would throw an error for any features without props
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urbaninstitute/dataviz-components",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urbaninstitute/dataviz-components",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@sveltejs/svelte-scroller": "^2.0.7",
         "@types/d3": "^7.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urbaninstitute/dataviz-components",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "dev": "npm run storybook",
     "build": "vite build && npm run package",

--- a/src/lib/maps/SVGMap/SVGMap.svelte
+++ b/src/lib/maps/SVGMap/SVGMap.svelte
@@ -80,6 +80,13 @@
    */
   export let tooltipContainParent = false;
 
+  /**
+   * whether to use a small (138px) or large (198px) width tooltip
+   * @type {"small" | "large"}
+   * @default "small"
+   */
+  export let tooltipSize = "small";
+
   const dispatch = createEventDispatcher();
 
   // create stores of map global settings to add to context
@@ -278,7 +285,7 @@
     </div>
   {/if}
   {#if tooltip}
-    <Tooltip x={tooltip.x} y={tooltip.y} containParent={tooltipContainParent}>
+    <Tooltip x={tooltip.x} y={tooltip.y} containParent={tooltipContainParent} size={tooltipSize}>
       <slot name="tooltip" props={tooltip.props}></slot>
     </Tooltip>
   {/if}


### PR DESCRIPTION
### What's in this pull request

- [ ] Bug fix
- [ ] New component/feature
- [x] Component update
- [ ] Documentation update
- [ ] Other

### Description

SVGMap now allows tooltip size to be configured

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
- [x] If this pull request includes a new component or feature, has it been exported from one of the library's entry points?
- [x] Does the component directory include description and usage information in `.stories.svelte`?
