### PR TITLE
Fix: Syntax error in toggle component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # @UrbanInstitute/dataviz-components Changelog
 
 ## Next
+- Fix: Syntax error in toggle component
 
 ## v1.0.5
 - Fix: SVGMap layers set pointer-events style property correctly

--- a/src/lib/Toggle/Toggle.svelte
+++ b/src/lib/Toggle/Toggle.svelte
@@ -37,7 +37,7 @@
   }}
   style:direction={labelPosition === "right" ? "rtl" : "ltr"}
   ><p class="label {labelPosition}">{label}</p>
-  <span class="toggle" aria-hidden="true"><span> class="circle"></span></span>
+  <span class="toggle" aria-hidden="true"><span class="circle"></span></span>
 </button>
 
 <style>


### PR DESCRIPTION
### What's in this pull request

- [x] Bug fix


### Description

Fixes syntax error in Toggle.svelte. Closes #148 

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
- [x] If this pull request includes a new component or feature, has it been exported from one of the library's entry points?
- [x] Does the component directory include description and usage information in `.stories.svelte`?
