### PR TITLE
Fix: ColorLegend story displays correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix: Syntax error in toggle component
 - Feat: Tooltip has pointerEvents prop
+- Fix: ColorLegend story now displays correctly
 
 ## v1.0.6
 

--- a/src/lib/maps/ColorLegend/ColorLegend.stories.svelte
+++ b/src/lib/maps/ColorLegend/ColorLegend.stories.svelte
@@ -4,7 +4,7 @@
   import docs from "./ColorLegend.docs.md?raw";
   import { defineMeta } from "@storybook/addon-svelte-csf";
 
-  export const { Story } = defineMeta({
+  const { Story } = defineMeta({
     title: "Maps/ColorLegend",
     component: ColorLegend,
     tags: ["autodocs"],


### PR DESCRIPTION
### What's in this pull request

- [x] Bug fix
- [ ] New component/feature
- [ ] Component update
- [ ] Documentation update
- [ ] Other

### Description

ColorLegend story displays correctly

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
- [x] If this pull request includes a new component or feature, has it been exported from one of the library's entry points?
- [x] Does the component directory include description and usage information in `.stories.svelte`?
