### PR TITLE
Fix: Storybook documentation organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: Syntax error in toggle component
 - Feat: Tooltip has pointerEvents prop
 - Fix: ColorLegend story now displays correctly
+- Fix: BasicPage and CustomSVGMap examples display in the correct section in the navigation
 
 ## v1.0.6
 

--- a/src/docs/BasicPage.docs.mdx
+++ b/src/docs/BasicPage.docs.mdx
@@ -1,7 +1,9 @@
 import { Meta, Canvas } from "@storybook/addon-docs/blocks";
 import * as stories from "./stories/BasicPage.stories.svelte";
 
-<Meta title="Examples/BasicPage" /># Basic Page example
+<Meta title="Examples/BasicPage" />
+
+# Basic Page example
 
 Here is an example that pieces together parts of this library into a basic page layout. Example source code is below.
 

--- a/src/docs/CustomSVGMap.docs.mdx
+++ b/src/docs/CustomSVGMap.docs.mdx
@@ -1,7 +1,9 @@
 import { Meta, Canvas, Story, Source } from "@storybook/addon-docs/blocks";
 import * as stories from "./stories/CustomSVGMap.stories.svelte";
 
-<Meta title="Examples/CustomSVGMap" /># Custom SVGMap example
+<Meta title="Examples/CustomSVGMap" />
+
+# Custom SVGMap example
 
 The `SVGMap` component and the associated layer components make it easy to create custom choropleth maps rendered with D3 projections and color scales. This example walks through the creation of a county level U.S. map showing the Urban Institute Upward Mobility Framework's Air Quality Index metric.
 


### PR DESCRIPTION
- CustomSVGMap and BasicPage examples show under examples heading in nav sidebar

### What's in this pull request

- [x] Bug fix


### Description

Fixes ordering of storybook stories

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
- [x] If this pull request includes a new component or feature, has it been exported from one of the library's entry points?
- [x] Does the component directory include description and usage information in `.stories.svelte`?
