### PR TITLE
Improve tilemap component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # @UrbanInstitute/dataviz-components Changelog
 
 ## Next
+- Fix: tilemap tooltip no longer lingers after mouseout
+- Fix: tilemap strokes no longer cut off
+- Feat: tilemap supports "nodc" layout
 
 ## v2.1.0
 - Fix: only use sticky highlight when using tooltip in SVGMap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # @UrbanInstitute/dataviz-components Changelog
 
 ## Next
+
 - Fix: tilemap tooltip no longer lingers after mouseout
 - Fix: tilemap strokes no longer cut off
 - Feat: tilemap supports "nodc" layout
 
 ## v2.1.0
+
 - Fix: only use sticky highlight when using tooltip in SVGMap
 - Fix: update SVGMap's internal getHighlightFeature to work with new interaction functionality
 
@@ -15,11 +17,10 @@
 - Breaking: <Scrolly> now accepts snippet props for custom background/foreground content and replaces getContext("scrolly") stores with the new useScrollyContext() helper; update slot markup and context access accordingly.
 - Breaking: SVGMap and its layer components now expose pointer interaction callbacks via props (onclick/onmousemove/onmouseout/onbgclick) instead of on:event listeners, and shared state is provided through useSVGMapContext()—replace any getContext("map") usage and update handler wiring.
 - Breaking: DatawrapperIframe emits interaction hooks through lowercase callback props such as
-onvisrendered/onregionclick instead of Svelte on:event listeners; pass handler functions as props to receive chart events.
+  onvisrendered/onregionclick instead of Svelte on:event listeners; pass handler functions as props to receive chart events.
 - Breaking: The exported pymChildStore writable has been removed in favor of the rune-based
-usePymChildContext() helper returned by <PymChild>; import usePymChildContext() to interact with the active pym.js child instance.
+  usePymChildContext() helper returned by <PymChild>; import usePymChildContext() to interact with the active pym.js child instance.
 - Feat: All components use Svelte 5 runes syntax and move away from store-based state where possible.
-
 
 ## v1.0.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: tilemap tooltip no longer lingers after mouseout
 - Fix: tilemap strokes no longer cut off
 - Feat: tilemap supports "nodc" layout
+- Feat: add accessibility labels to tilemap
 
 ## v2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Fix: tilemap strokes no longer cut off
 - Feat: tilemap supports "nodc" layout
 - Feat: add accessibility labels to tilemap
+- Fix: Tilemap no longer emits an unlabelled `role="img"` by default; the SVG is now hidden from assistive technology via `aria-hidden` when no aria props are provided, consistent with SVGMap
+- Deprecated: Tilemap's `ariaLabel` prop is deprecated in favor of `ariaTitle`; `ariaLabel` still works but logs a console warning pointing to the preferred prop
+- Feat: All Tilemap Storybook stories now include `ariaTitle` demonstrating accessibility best practices; new stories added for `highlightFeature`, `hoverFill`, and accessibility props
 
 ## v2.1.0
 

--- a/src/lib/maps/Tilemap/Tilemap.stories.svelte
+++ b/src/lib/maps/Tilemap/Tilemap.stories.svelte
@@ -43,6 +43,10 @@
   let bgClickHandler = fn();
 </script>
 
+<script>
+  let highlightedFips = $state(null);
+</script>
+
 {#snippet template(args)}
   <Tilemap {...args}>
     {#snippet tooltip(props)}
@@ -60,6 +64,7 @@
     fill: (d) => mapColorScale(d?.value),
     hoverStroke: urbanColors.yellow,
     hoverStrokeWidth: 3,
+    ariaTitle: "U.S. state-level tilemap showing sample values by state",
     onBgclick: bgClickHandler,
     onMousemove: mousemoveHandler,
     onMouseout: mouseoutHandler,
@@ -85,7 +90,8 @@
     fill: (d) => mapColorScale(d?.value),
     stroke: urbanColors.white,
     hoverStroke: urbanColors.yellow,
-    hoverStrokeWidth: 3
+    hoverStrokeWidth: 3,
+    ariaTitle: "U.S. state-level tilemap using rectangular tiles showing sample values by state"
   }}
   {template}
 />
@@ -99,7 +105,8 @@
       fill: (d) => mapColorScale(d?.value),
       stroke: urbanColors.white,
       hoverStroke: urbanColors.yellow,
-      hoverStrokeWidth: 3
+      hoverStrokeWidth: 3,
+      ariaTitle: "U.S. state and territory tilemap showing sample values"
     }}
   >
     {#snippet tooltip(props)}
@@ -107,3 +114,67 @@
     {/snippet}
   </Tilemap>
 </Story>
+
+<Story name="Highlight Feature" asChild>
+  <Tilemap
+    data={testData}
+    shape="hex"
+    fill={(d) => mapColorScale(d?.value)}
+    stroke={urbanColors.white}
+    hoverStroke={urbanColors.yellow}
+    hoverStrokeWidth={3}
+    highlightFeature={highlightedFips}
+    ariaTitle="U.S. state-level tilemap — click a state to highlight it"
+    onClick={(_, props) => {
+      highlightedFips = highlightedFips === props?.map_id ? null : props?.map_id;
+    }}
+  >
+    {#snippet tooltip(props)}
+      <strong>{props.map_id}: </strong>{props.value}
+    {/snippet}
+  </Tilemap>
+</Story>
+
+<Story
+  name="Hover Fill"
+  args={{
+    data: testData,
+    shape: "hex",
+    fill: (d) => mapColorScale(d?.value),
+    stroke: urbanColors.white,
+    hoverFill: urbanColors.yellow,
+    hoverStroke: urbanColors.yellow,
+    hoverStrokeWidth: 3,
+    highlightFeature: "06",
+    ariaTitle: "U.S. state-level tilemap demonstrating hover fill — California is pre-highlighted"
+  }}
+  {template}
+/>
+
+<Story
+  name="Accessibility"
+  args={{
+    data: testData,
+    shape: "hex",
+    fill: (d) => mapColorScale(d?.value),
+    stroke: urbanColors.white,
+    hoverStroke: urbanColors.yellow,
+    hoverStrokeWidth: 3,
+    ariaTitle: "U.S. state-level tilemap showing sample values by state",
+    ariaDescription:
+      "States in the Northeast and West Coast tend to have higher values in this dataset."
+  }}
+  play={async ({ canvasElement }) => {
+    const svg = canvasElement.querySelector("svg");
+    await expect(svg).toHaveAttribute("role", "img");
+    await expect(svg).not.toHaveAttribute("aria-hidden");
+    const labelledBy = svg.getAttribute("aria-labelledby");
+    await expect(labelledBy).toBeTruthy();
+    const titleEl = canvasElement.querySelector(`#${labelledBy.split(" ")[0]}`);
+    await expect(titleEl).toBeTruthy();
+    await expect(titleEl.textContent).toBe(
+      "U.S. state-level tilemap showing sample values by state"
+    );
+  }}
+  {template}
+/>

--- a/src/lib/maps/Tilemap/Tilemap.svelte
+++ b/src/lib/maps/Tilemap/Tilemap.svelte
@@ -21,7 +21,9 @@
    * @property {number} [strokeWidth=1] Stroke width of each feature
    * @property {number | undefined} [hoverStrokeWidth=undefined] Stroke width of each feature when hovered
    * @property {string | undefined} [highlightFeature=undefined] ID of the feature to highlight
-   * @property {string | undefined} [ariaRole=undefined] Optional aria role string to be applied to SVG container. By default, the SVG is hidden from the accessiblity tree. If you add an ariaRole here, any layers should also be given an ariaRole.
+   * @property {string | undefined} [ariaTitle=undefined] Optional accessible title for the SVG. When provided, renders a <title> element inside the SVG and automatically sets role="img" with aria-labelledby. Should describe what the map shows (e.g. "U.S. state-level data map showing unemployment rates").
+   * @property {string | undefined} [ariaDescription=undefined] Optional longer accessible description for the SVG. When provided alongside ariaTitle, renders a <desc> element and includes it in aria-labelledby. Should convey the key takeaway of the visualization.
+   * @property {string | undefined} [ariaRole=undefined] Optional aria role string to be applied to SVG container. Overrides the automatic role="img" set by ariaTitle. By default, the SVG is hidden from the accessiblity tree.
    * @property {string | undefined} [ariaLabel=undefined] Optional aria label string to be applied to SVG container. By default, the SVG is hidden from the accessiblity tree and should include a descriptive label. If you add an ariaRole this property can be left undefined;
    * @property {string} [labelColor=urbanColors.black] Optional color string to use for the labels on the map
    * @property {(e: MouseEvent, props: Record<any, any>) => void} [onMousemove=() => {}] Optional handler that fires when the mouse moves over a feature
@@ -44,6 +46,8 @@
     strokeWidth = 1,
     hoverStrokeWidth,
     highlightFeature,
+    ariaTitle,
+    ariaDescription,
     ariaRole,
     ariaLabel,
     labelColor = urbanColors.black,
@@ -53,6 +57,19 @@
     onBgclick = () => {},
     tooltip = undefined
   } = $props();
+
+  const uid = Math.random().toString(36).slice(2, 9);
+  const titleId = `tilemap-title-${uid}`;
+  const descId = `tilemap-desc-${uid}`;
+
+  let svgRole = $derived(ariaRole ?? "img");
+  let svgAriaLabelledby = $derived(
+    ariaTitle
+      ? ariaDescription
+        ? `${titleId} ${descId}`
+        : titleId
+      : undefined
+  );
 
   const featureFilters = {
     states: ["PR", "VI", "MP", "GU", "AS"],
@@ -277,11 +294,21 @@
 <div
   class="tile-map-wrap"
   bind:clientWidth={width}
-  aria-hidden={typeof ariaRole === "undefined" ? "true" : undefined}
-  role={ariaRole}
-  aria-label={ariaLabel}
 >
-  <svg {width} {height} viewBox="0 0 {width} {height}">
+  <svg
+    {width}
+    {height}
+    viewBox="0 0 {width} {height}"
+    role={svgRole}
+    aria-label={ariaLabel}
+    aria-labelledby={svgAriaLabelledby}
+  >
+    {#if ariaTitle}
+      <title id={titleId}>{ariaTitle}</title>
+    {/if}
+    {#if ariaDescription}
+      <desc id={descId}>{ariaDescription}</desc>
+    {/if}
     {#snippet tileShape(rowIndex, columnIndex, attrs)}
       {#if shape === "hex"}
         <path

--- a/src/lib/maps/Tilemap/Tilemap.svelte
+++ b/src/lib/maps/Tilemap/Tilemap.svelte
@@ -6,29 +6,29 @@
   import Tooltip from "$lib/Tooltip/Tooltip.svelte";
 
   /** @typedef {"states" | "pr" | "territories" | "nodc"} FeatureOptions */
-  /** @typedef {"hex" | "rext"} ShapeOption */
+  /** @typedef {"hex" | "rect"} ShapeOption */
 
   /**
    * @typedef {Object} TilemapProps
    * @property {Object<string, any>[]} data
    * @property {ShapeOption} [shape="hex"]
    * @property {FeatureOptions} [featureOption="states"]
-   * @property {string | ((d: Object<string, any>) => string)} [fill=urbanColors.blue] A string or function that returns a string to use as this layers stroke color.
+   * @property {string | ((d: Object<string, any>) => string)} [fill=urbanColors.blue] A string or function that returns a string to use as this layers fill color.
    * @property {string | undefined} [hoverFill=undefined] A color string to use when a feature is hovered
    * @property {string} [naFill=urbanColors.gray_shade_light] Color to use for values that are NA or otherwise undefined in the color scale
    * @property {string | ((d: Object) => string)} [stroke=urbanColors.white] A string or function that returns a string to use as this layers stroke color.
    * @property {string | undefined} [hoverStroke=undefined] Optional color string for hovered feature stroke
-   * @property {number} [strokeWidth=0.5] Stroke width of each feature
+   * @property {number} [strokeWidth=1] Stroke width of each feature
    * @property {number | undefined} [hoverStrokeWidth=undefined] Stroke width of each feature when hovered
    * @property {string | undefined} [highlightFeature=undefined] ID of the feature to highlight
    * @property {string | undefined} [ariaRole=undefined] Optional aria role string to be applied to SVG container. By default, the SVG is hidden from the accessiblity tree. If you add an ariaRole here, any layers should also be given an ariaRole.
    * @property {string | undefined} [ariaLabel=undefined] Optional aria label string to be applied to SVG container. By default, the SVG is hidden from the accessiblity tree and should include a descriptive label. If you add an ariaRole this property can be left undefined;
    * @property {string} [labelColor=urbanColors.black] Optional color string to use for the labels on the map
-   * @property {(e: Event, props: Record<any, any>) => void} [onMousemove=() => {}] Optional handler that fires when the mouse moves over a feature
-   * @property {(e: Event) => void} [onMouseout=() => {}] Optional handler that fires when the mouse moves out of a feature
-   * @property {(e: Event, props: Record<any, any>) => void} [onClick=() => {}] Optional handler that fires when the mouse clicks on a feature
+   * @property {(e: MouseEvent, props: Record<any, any>) => void} [onMousemove=() => {}] Optional handler that fires when the mouse moves over a feature
+   * @property {(e: MouseEvent) => void} [onMouseout=() => {}] Optional handler that fires when the mouse moves out of a feature
+   * @property {(e: MouseEvent, props: Record<any, any>) => void} [onClick=() => {}] Optional handler that fires when the mouse clicks on a feature
    * @property {(e: Event) => void} [onBgclick=() => {}] Optional handler that fires when the mouse clicks on the background
-   * @property {@import("svelte").Snippet} [tooltip] Optional snippet for rendering a tooltip, receives hovered feature props
+   * @property {import("svelte").Snippet} [tooltip] Optional snippet for rendering a tooltip, receives hovered feature props
    */
 
   /** @type {TilemapProps} */
@@ -41,7 +41,7 @@
     naFill = urbanColors.gray_shade_light,
     stroke = urbanColors.white,
     hoverStroke,
-    strokeWidth = 0.5,
+    strokeWidth = 1,
     hoverStrokeWidth,
     highlightFeature,
     ariaRole,
@@ -92,7 +92,7 @@
   );
   let shapeWidth = $derived(Math.floor(width / mapTiles[0].length));
   let shapeHeight = $derived(getHeight(shapeWidth, shape));
-  let height = $derived(getMapHeight(activeRows, shapeHeight, shape));
+  let height = $derived(getMapHeight(activeRows, shapeHeight, shape, hoverStrokeWidth));
 
   /**
    * @param { number } width
@@ -113,16 +113,16 @@
    * @param {ShapeOption} shapeType - The shape type of the map.
    * @returns {number}
    */
-  function getMapHeight(numRows, unitHeight, shapeType) {
+  function getMapHeight(numRows, unitHeight, shapeType, hoverStrokeW = 0) {
     if (shapeType === "hex") {
       return (
         numRows * (unitHeight / 2) +
         unitHeight * 2.25 +
         (numRows % 2) * (unitHeight * 0.25) +
-        (hoverStrokeWidth || 0)
+        (hoverStrokeW || 0)
       );
     }
-    return numRows * unitHeight + (hoverStrokeWidth || 0);
+    return numRows * unitHeight + (hoverStrokeW || 0);
   }
 
   /**
@@ -195,6 +195,18 @@
   }
 
   /**
+   * @param {Object<string, any>} feature
+   * @param {string|((feature: Object<string, any>) => string)} stroke
+   * @returns {string}
+   */
+  function getStroke(feature, stroke) {
+    if (typeof stroke === "string") {
+      return stroke;
+    }
+    return stroke(feature);
+  }
+
+  /**
    * Get the feature data for a given abbreviation.
    * @param {string} abbr - The state or territory abbreviation.
    * @returns {Object|null}
@@ -219,7 +231,7 @@
   let hoveredTile = $state(null);
 
   /**
-   * @param { Event } e
+   * @param { MouseEvent } e
    * @param { string } tile
    */
   function handleMousemove(e, tile) {
@@ -234,7 +246,7 @@
   }
 
   /**
-   * @param { Event } e
+   * @param { MouseEvent } e
    */
   function handleMouseout(e) {
     tooltipData = null;
@@ -243,8 +255,7 @@
   }
 
   /**
-   *
-   * @param { Event } e
+   * @param { MouseEvent } e
    * @param { string } state
    */
   function handleClick(e, state) {
@@ -261,13 +272,12 @@
   function getHighlight(fips, highlight) {
     return fips === highlight;
   }
-
 </script>
 
 <div
   class="tile-map-wrap"
   bind:clientWidth={width}
-  aria-hidden={typeof ariaRole === "undefined"}
+  aria-hidden={typeof ariaRole === "undefined" ? "true" : undefined}
   role={ariaRole}
   aria-label={ariaLabel}
 >
@@ -310,15 +320,15 @@
       }}
     ></rect>
     <g class="tiles" style:--hover-fill={hoverFill || null} class:hover-fill={hoverFill}>
-      {#each mapTiles as row, rowIndex}
-        {#each row as tile, columnIndex}
+      {#each mapTiles as row, rowIndex (rowIndex)}
+        {#each row as tile, columnIndex (columnIndex)}
           {#if tile.trim() !== ""}
             {@render tileShape(rowIndex, columnIndex, {
               class:
                 "tile-shape" +
                 (getHighlight(fipsMap.get(tile), highlightFeature) ? " highlight" : ""),
               fill: getFill(getFeatureData(tile), fill, naFill),
-              stroke,
+              stroke: getStroke(getFeatureData(tile), stroke),
               "stroke-width": strokeWidth,
               role: "presentation",
               onmousemove: (e) => handleMousemove(e, tile),
@@ -331,8 +341,8 @@
       {/each}
     </g>
     <g class="tile-outlines" pointer-events="none">
-      {#each mapTiles as row, rowIndex}
-        {#each row as tile, columnIndex}
+      {#each mapTiles as row, rowIndex (rowIndex)}
+        {#each row as tile, columnIndex (columnIndex)}
           <!-- Render outlines for any hovered or highlighted tiles -->
           {#if tile.trim() !== "" && (hoveredTile === tile || getHighlight(fipsMap.get(tile), highlightFeature))}
             {@render tileShape(rowIndex, columnIndex, {
@@ -345,8 +355,8 @@
       {/each}
     </g>
     <g class="map-labels" style:--font-weight="bold">
-      {#each mapTiles as row, rowIndex}
-        {#each row as tile, columnIndex}
+      {#each mapTiles as row, rowIndex (rowIndex)}
+        {#each row as tile, columnIndex (columnIndex)}
           {#if tile.trim() !== ""}
             <g
               class="tile"

--- a/src/lib/maps/Tilemap/Tilemap.svelte
+++ b/src/lib/maps/Tilemap/Tilemap.svelte
@@ -1,7 +1,7 @@
+<!-- A generative AI model wrote or edited portions of this file with the supervision of a human developer and careful human review. -->
 <script>
   import maplayout from "./layout_territories.txt?raw";
   import { urbanColors } from "$lib/utils";
-  import { tick } from "svelte";
   import { fipsMap } from "./fips.js";
   import Tooltip from "$lib/Tooltip/Tooltip.svelte";
 
@@ -214,41 +214,23 @@
     }
   }
 
-  // holds highlighted feature DOM element
-  /** @type { Element | null} */
-  let highlightFeatureNode = $state();
-
-  /** @type { Element } */
-  let el = $state();
-
   let tooltipData = $state(null);
+  let hoveredTile = $state(null);
 
-  /**
-   * Raise a dom node to top of siblings
-   * @param { Element } el The DOM element to raise
-   * @returns void
-   */
-  export function raise(el) {
-    el.parentNode?.appendChild(el);
-  }
   /**
    * @param { Event } e
-   * @param { string } state
+   * @param { string } tile
+   * @param { number } rowIndex
+   * @param { number } columnIndex
    */
-  function handleMousemove(e, state) {
-    if (e.target && e.target instanceof Element) {
-      raise(e.target);
-    }
-    if (highlightFeatureNode) {
-      raise(highlightFeatureNode);
-    }
-
-    const props = getFeatureData(state);
+  function handleMousemove(e, tile, rowIndex, columnIndex) {
+    const props = getFeatureData(tile);
     tooltipData = {
       props,
       x: e.pageX,
       y: e.pageY
     };
+    hoveredTile = { tile, rowIndex, columnIndex };
     onMousemove(e, props);
   }
 
@@ -257,6 +239,7 @@
    */
   function handleMouseout(e) {
     tooltipData = null;
+    hoveredTile = null;
     onMouseout(e);
   }
 
@@ -266,18 +249,9 @@
    * @param { string } state
    */
   function handleClick(e, state) {
-    if (e.target instanceof Element) {
-      raise(e.target);
-    }
     const props = getFeatureData(state);
     onClick(e, props);
   }
-
-  $effect(() => {
-    if (highlightFeatureNode) {
-      raise(highlightFeatureNode);
-    }
-  });
 
   /**
    * Returns true if the given fips matches the highlight value.
@@ -288,10 +262,6 @@
   function getHighlight(fips, highlight) {
     return fips === highlight;
   }
-
-  tick(() => {
-    highlightFeatureNode = el.querySelector("path.highlight");
-  });
 </script>
 
 <div
@@ -301,7 +271,23 @@
   role={ariaRole}
   aria-label={ariaLabel}
 >
-  <svg bind:this={el} {width} {height} viewBox="0 0 {width} {height}">
+  <svg {width} {height} viewBox="0 0 {width} {height}">
+    {#snippet tileShape(rowIndex, columnIndex, attrs)}
+      {#if shape === "hex"}
+        <path
+          d={hexPoints}
+          transform="translate({getX(columnIndex, rowIndex, shapeWidth)}, {getY(rowIndex, shapeHeight)})"
+          {...attrs}
+        ></path>
+      {:else if shape === "rect"}
+        <rect
+          width={shapeWidth}
+          height={shapeHeight}
+          transform="translate({getX(columnIndex, rowIndex, shapeWidth)}, {getY(rowIndex, shapeHeight)})"
+          {...attrs}
+        ></rect>
+      {/if}
+    {/snippet}
     <rect
       role="presentation"
       class="background"
@@ -311,55 +297,47 @@
       {width}
       {height}
       onmousedown={(e) => onBgclick(e)}
+      onpointermove={(e) => {
+        tooltipData = null;
+        hoveredTile = null;
+        onMouseout(e);
+      }}
     ></rect>
     <g
       class="tiles"
       style:--hover-fill={hoverFill || null}
-      style:--hover-stroke={hoverStroke || null}
-      style:--hover-stroke-width={hoverStrokeWidth || strokeWidth}
       class:hover-fill={hoverFill}
     >
       {#each mapTiles as row, rowIndex}
         {#each row as tile, columnIndex}
           {#if tile.trim() !== ""}
-            {#if shape === "hex"}
-              <path
-                class="tile-shape"
-                d={hexPoints}
-                fill={getFill(getFeatureData(tile), fill, naFill)}
-                transform="translate({getX(columnIndex, rowIndex, shapeWidth)}, {getY(
-                  rowIndex,
-                  shapeHeight
-                )})"
-                {stroke}
-                stroke-width={strokeWidth}
-                role="presentation"
-                class:highlight={getHighlight(fipsMap.get(tile), highlightFeature)}
-                onmousemove={(e) => handleMousemove(e, tile)}
-                onmouseout={handleMouseout}
-                onblur={handleMouseout}
-                onmousedown={(e) => handleClick(e, tile)}
-              ></path>
-            {:else if shape === "rect"}
-              <rect
-                class="tile-shape"
-                width={shapeWidth}
-                height={shapeHeight}
-                transform="translate({getX(columnIndex, rowIndex, shapeWidth)}, {getY(
-                  rowIndex,
-                  shapeHeight
-                )})"
-                fill={getFill(getFeatureData(tile), fill, naFill)}
-                {stroke}
-                stroke-width={strokeWidth}
-                role="presentation"
-                class:highlight={getHighlight(fipsMap.get(tile), highlightFeature)}
-                onmousemove={(e) => handleMousemove(e, tile)}
-                onmouseout={handleMouseout}
-                onblur={handleMouseout}
-                onmousedown={(e) => handleClick(e, tile)}
-              ></rect>
-            {/if}
+            {@render tileShape(rowIndex, columnIndex, {
+              class: "tile-shape" + (getHighlight(fipsMap.get(tile), highlightFeature) ? " highlight" : ""),
+              fill: getFill(getFeatureData(tile), fill, naFill),
+              stroke,
+              "stroke-width": strokeWidth,
+              role: "presentation",
+              onmousemove: (e) => handleMousemove(e, tile, rowIndex, columnIndex),
+              onmouseout: handleMouseout,
+              onblur: handleMouseout,
+              onmousedown: (e) => handleClick(e, tile)
+            })}
+          {/if}
+        {/each}
+      {/each}
+    </g>
+    <g class="tile-outlines" pointer-events="none">
+      {#each mapTiles as row, rowIndex}
+        {#each row as tile, columnIndex}
+          {#if tile.trim() !== "" && (
+            (hoveredTile?.tile === tile && hoveredTile?.rowIndex === rowIndex && hoveredTile?.columnIndex === columnIndex) ||
+            getHighlight(fipsMap.get(tile), highlightFeature)
+          )}
+            {@render tileShape(rowIndex, columnIndex, {
+              fill: "none",
+              stroke: hoverStroke || stroke,
+              "stroke-width": hoverStrokeWidth || strokeWidth
+            })}
           {/if}
         {/each}
       {/each}
@@ -415,11 +393,6 @@
 <style>
   .tile-shape {
     cursor: pointer;
-  }
-  .tile-shape:hover,
-  .tile-shape.highlight {
-    stroke: var(--hover-stroke);
-    stroke-width: var(--hover-stroke-width);
   }
   .hover-fill .tile-shape:hover,
   .hover-fill .tile-shape.highlight {

--- a/src/lib/maps/Tilemap/Tilemap.svelte
+++ b/src/lib/maps/Tilemap/Tilemap.svelte
@@ -221,17 +221,15 @@
   /**
    * @param { Event } e
    * @param { string } tile
-   * @param { number } rowIndex
-   * @param { number } columnIndex
    */
-  function handleMousemove(e, tile, rowIndex, columnIndex) {
+  function handleMousemove(e, tile) {
     const props = getFeatureData(tile);
     tooltipData = {
       props,
       x: e.pageX,
       y: e.pageY
     };
-    hoveredTile = { tile, rowIndex, columnIndex };
+    hoveredTile = tile;
     onMousemove(e, props);
   }
 
@@ -263,6 +261,7 @@
   function getHighlight(fips, highlight) {
     return fips === highlight;
   }
+
 </script>
 
 <div
@@ -322,7 +321,7 @@
               stroke,
               "stroke-width": strokeWidth,
               role: "presentation",
-              onmousemove: (e) => handleMousemove(e, tile, rowIndex, columnIndex),
+              onmousemove: (e) => handleMousemove(e, tile),
               onmouseout: handleMouseout,
               onblur: handleMouseout,
               onmousedown: (e) => handleClick(e, tile)
@@ -334,7 +333,8 @@
     <g class="tile-outlines" pointer-events="none">
       {#each mapTiles as row, rowIndex}
         {#each row as tile, columnIndex}
-          {#if tile.trim() !== "" && ((hoveredTile?.tile === tile && hoveredTile?.rowIndex === rowIndex && hoveredTile?.columnIndex === columnIndex) || getHighlight(fipsMap.get(tile), highlightFeature))}
+          <!-- Render outlines for any hovered or highlighted tiles -->
+          {#if tile.trim() !== "" && (hoveredTile === tile || getHighlight(fipsMap.get(tile), highlightFeature))}
             {@render tileShape(rowIndex, columnIndex, {
               fill: "none",
               stroke: hoverStroke || stroke,

--- a/src/lib/maps/Tilemap/Tilemap.svelte
+++ b/src/lib/maps/Tilemap/Tilemap.svelte
@@ -277,14 +277,20 @@
       {#if shape === "hex"}
         <path
           d={hexPoints}
-          transform="translate({getX(columnIndex, rowIndex, shapeWidth)}, {getY(rowIndex, shapeHeight)})"
+          transform="translate({getX(columnIndex, rowIndex, shapeWidth)}, {getY(
+            rowIndex,
+            shapeHeight
+          )})"
           {...attrs}
         ></path>
       {:else if shape === "rect"}
         <rect
           width={shapeWidth}
           height={shapeHeight}
-          transform="translate({getX(columnIndex, rowIndex, shapeWidth)}, {getY(rowIndex, shapeHeight)})"
+          transform="translate({getX(columnIndex, rowIndex, shapeWidth)}, {getY(
+            rowIndex,
+            shapeHeight
+          )})"
           {...attrs}
         ></rect>
       {/if}
@@ -304,16 +310,14 @@
         onMouseout(e);
       }}
     ></rect>
-    <g
-      class="tiles"
-      style:--hover-fill={hoverFill || null}
-      class:hover-fill={hoverFill}
-    >
+    <g class="tiles" style:--hover-fill={hoverFill || null} class:hover-fill={hoverFill}>
       {#each mapTiles as row, rowIndex}
         {#each row as tile, columnIndex}
           {#if tile.trim() !== ""}
             {@render tileShape(rowIndex, columnIndex, {
-              class: "tile-shape" + (getHighlight(fipsMap.get(tile), highlightFeature) ? " highlight" : ""),
+              class:
+                "tile-shape" +
+                (getHighlight(fipsMap.get(tile), highlightFeature) ? " highlight" : ""),
               fill: getFill(getFeatureData(tile), fill, naFill),
               stroke,
               "stroke-width": strokeWidth,
@@ -330,10 +334,7 @@
     <g class="tile-outlines" pointer-events="none">
       {#each mapTiles as row, rowIndex}
         {#each row as tile, columnIndex}
-          {#if tile.trim() !== "" && (
-            (hoveredTile?.tile === tile && hoveredTile?.rowIndex === rowIndex && hoveredTile?.columnIndex === columnIndex) ||
-            getHighlight(fipsMap.get(tile), highlightFeature)
-          )}
+          {#if tile.trim() !== "" && ((hoveredTile?.tile === tile && hoveredTile?.rowIndex === rowIndex && hoveredTile?.columnIndex === columnIndex) || getHighlight(fipsMap.get(tile), highlightFeature))}
             {@render tileShape(rowIndex, columnIndex, {
               fill: "none",
               stroke: hoverStroke || stroke,

--- a/src/lib/maps/Tilemap/Tilemap.svelte
+++ b/src/lib/maps/Tilemap/Tilemap.svelte
@@ -5,14 +5,14 @@
   import { fipsMap } from "./fips.js";
   import Tooltip from "$lib/Tooltip/Tooltip.svelte";
 
-  /** @typedef {"states" | "pr" | "territories"} FeatureOptions */
+  /** @typedef {"states" | "pr" | "territories" | "nodc"} FeatureOptions */
   /** @typedef {"hex" | "rext"} ShapeOption */
 
   /**
    * @typedef {Object} TilemapProps
    * @property {Object<string, any>[]} data
    * @property {ShapeOption} [shape="hex"]
-   * @property {import("$utils/states").FeatureOptions} [featureOption="states"]
+   * @property {FeatureOptions} [featureOption="states"]
    * @property {string | ((d: Object<string, any>) => string)} [fill=urbanColors.blue] A string or function that returns a string to use as this layers stroke color.
    * @property {string | undefined} [hoverFill=undefined] A color string to use when a feature is hovered
    * @property {string} [naFill=urbanColors.gray_shade_light] Color to use for values that are NA or otherwise undefined in the color scale
@@ -56,6 +56,7 @@
 
   const featureFilters = {
     states: ["PR", "VI", "MP", "GU", "AS"],
+    nodc: ["PR", "VI", "MP", "GU", "AS", "DC"],
     pr: ["VI", "MP", "GU", "AS"],
     territories: []
   };

--- a/src/lib/maps/Tilemap/Tilemap.svelte
+++ b/src/lib/maps/Tilemap/Tilemap.svelte
@@ -21,10 +21,10 @@
    * @property {number} [strokeWidth=1] Stroke width of each feature
    * @property {number | undefined} [hoverStrokeWidth=undefined] Stroke width of each feature when hovered
    * @property {string | undefined} [highlightFeature=undefined] ID of the feature to highlight
-   * @property {string | undefined} [ariaTitle=undefined] Optional accessible title for the SVG. When provided, renders a <title> element inside the SVG and automatically sets role="img" with aria-labelledby. Should describe what the map shows (e.g. "U.S. state-level data map showing unemployment rates").
+   * @property {string | undefined} [ariaTitle=undefined] Accessible title for the SVG. When provided, renders a <title> element inside the SVG, sets role="img", and wires up aria-labelledby automatically. Should describe what the map shows (e.g. "U.S. state-level map showing unemployment rates"). This is the preferred way to make the map accessible.
    * @property {string | undefined} [ariaDescription=undefined] Optional longer accessible description for the SVG. When provided alongside ariaTitle, renders a <desc> element and includes it in aria-labelledby. Should convey the key takeaway of the visualization.
-   * @property {string | undefined} [ariaRole=undefined] Optional aria role string to be applied to SVG container. Overrides the automatic role="img" set by ariaTitle. By default, the SVG is hidden from the accessiblity tree.
-   * @property {string | undefined} [ariaLabel=undefined] Optional aria label string to be applied to SVG container. By default, the SVG is hidden from the accessiblity tree and should include a descriptive label. If you add an ariaRole this property can be left undefined;
+   * @property {string | undefined} [ariaRole=undefined] Optional aria role override for the SVG container. Only needed in unusual cases — ariaTitle handles role="img" automatically. When neither ariaTitle nor ariaRole is set, the SVG is hidden from the accessibility tree via aria-hidden.
+   * @property {string | undefined} [ariaLabel=undefined] @deprecated Use ariaTitle instead. If provided without ariaTitle, falls back to setting aria-label directly on the SVG. Will log a deprecation warning in development.
    * @property {string} [labelColor=urbanColors.black] Optional color string to use for the labels on the map
    * @property {(e: MouseEvent, props: Record<any, any>) => void} [onMousemove=() => {}] Optional handler that fires when the mouse moves over a feature
    * @property {(e: MouseEvent) => void} [onMouseout=() => {}] Optional handler that fires when the mouse moves out of a feature
@@ -62,14 +62,25 @@
   const titleId = `tilemap-title-${uid}`;
   const descId = `tilemap-desc-${uid}`;
 
-  let svgRole = $derived(ariaRole ?? "img");
+  // Warn when the deprecated ariaLabel prop is used
+  $effect(() => {
+    if (ariaLabel && !ariaTitle) {
+      console.warn(
+        "[Tilemap] The ariaLabel prop is deprecated. Use ariaTitle instead — it renders a proper SVG <title> element and wires up aria-labelledby automatically."
+      );
+    }
+  });
+
+  // When ariaTitle is provided, role="img" is set automatically.
+  // When ariaRole is explicitly provided, that role is used as-is.
+  // Otherwise the SVG is hidden from the accessibility tree via aria-hidden.
+  let svgRole = $derived(ariaTitle ? "img" : ariaRole);
+  let svgAriaHidden = $derived(!ariaTitle && !ariaRole ? true : undefined);
   let svgAriaLabelledby = $derived(
-    ariaTitle
-      ? ariaDescription
-        ? `${titleId} ${descId}`
-        : titleId
-      : undefined
+    ariaTitle ? (ariaDescription ? `${titleId} ${descId}` : titleId) : undefined
   );
+  // ariaLabel is deprecated: only pass it through when ariaTitle is not set
+  let svgAriaLabel = $derived(!ariaTitle ? ariaLabel : undefined);
 
   const featureFilters = {
     states: ["PR", "VI", "MP", "GU", "AS"],
@@ -291,16 +302,14 @@
   }
 </script>
 
-<div
-  class="tile-map-wrap"
-  bind:clientWidth={width}
->
+<div class="tile-map-wrap" bind:clientWidth={width}>
   <svg
     {width}
     {height}
     viewBox="0 0 {width} {height}"
     role={svgRole}
-    aria-label={ariaLabel}
+    aria-hidden={svgAriaHidden}
+    aria-label={svgAriaLabel}
     aria-labelledby={svgAriaLabelledby}
   >
     {#if ariaTitle}

--- a/src/lib/maps/Tilemap/layout.txt
+++ b/src/lib/maps/Tilemap/layout.txt
@@ -1,9 +1,0 @@
-AK,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,ME
-  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,VT,NH
-  ,  ,WA,MT,ND,MN,WI,  ,MI,  ,NY,MA,RI
-  ,  ,  ,ID,WY,SD,IA,IL,IN,OH,PA,NJ,CT
-  ,  ,OR,NV,CO,NE,MO,KY,WV,VA,MD,DE,
-  ,  ,  ,CA,UT,NM,KS,AR,TN,NC,SC,DC,
-  ,  ,  ,  ,AZ,OK,LA,MS,AL,GA,  ,  ,
-  ,  ,HI,  ,  ,  ,TX,  ,  ,FL,  ,  ,
-  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,

--- a/src/lib/maps/Tilemap/layout_pr.txt
+++ b/src/lib/maps/Tilemap/layout_pr.txt
@@ -1,9 +1,0 @@
-AK,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,ME
-  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,VT,NH
-  ,  ,WA,MT,ND,MN,WI,  ,MI,  ,NY,MA,RI
-  ,  ,  ,ID,WY,SD,IA,IL,IN,OH,PA,NJ,CT
-  ,  ,OR,NV,CO,NE,MO,KY,WV,VA,MD,DE,
-  ,  ,  ,CA,UT,NM,KS,AR,TN,NC,SC,DC,
-  ,  ,  ,  ,AZ,OK,LA,MS,AL,GA,  ,  ,
-  ,  ,HI,  ,  ,  ,TX,  ,  ,FL,  ,  ,
-  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,PR,


### PR DESCRIPTION
### What's in this pull request

- [x] Bug fix


### Description
- Fixes issue with tilemap where tooltip would sometimes linger after mouseout. 
- Fixes issue where stroke was sometimes cut off.
- Adds "nodc" option to tilemap closes #173 

### Before submitting, please check that you've

- [x] Formatted your code correctly (i.e., prettier cleaned it up)
- [x] Documented any new components or features
- [x] Added any changes in this PR to the `CHANGELOG.md` `Next` section
- [x] If this pull request includes a new component or feature, has it been exported from one of the library's entry points?
- [x] Does the component directory include description and usage information in `.stories.svelte`?
